### PR TITLE
fix(workflows): fix detect-changes for push events to main

### DIFF
--- a/.github/actions/detect-pipeline-changes/action.yml
+++ b/.github/actions/detect-pipeline-changes/action.yml
@@ -22,6 +22,16 @@
 name: Detect Pipeline Changes
 description: Detects which parts of the codebase have changed to optimize pipeline execution
 
+inputs:
+  base-sha:
+    description: 'Base commit SHA to compare against (defaults to auto-detect based on event type)'
+    required: false
+    default: ''
+  head-sha:
+    description: 'Head commit SHA to compare (defaults to HEAD)'
+    required: false
+    default: 'HEAD'
+
 outputs:
   changed_areas:
     description: Space-separated list of changed areas (e.g., "apps/web services/api k8s")
@@ -36,4 +46,10 @@ runs:
     - name: Detect changes
       id: detect
       shell: pwsh
-      run: .\scripts\ci\detect-changes.ps1 -OutputFormat github-actions
+      env:
+        BASE_SHA_INPUT: ${{ inputs.base-sha }}
+        HEAD_SHA_INPUT: ${{ inputs.head-sha }}
+      run: |
+        $baseShaParam = if ($env:BASE_SHA_INPUT) { "-BaseSha", $env:BASE_SHA_INPUT } else { @() }
+        $headShaParam = if ($env:HEAD_SHA_INPUT) { "-HeadSha", $env:HEAD_SHA_INPUT } else { @() }
+        & .\scripts\ci\detect-changes.ps1 @baseShaParam @headShaParam -OutputFormat github-actions

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Detect changes
         id: detect
         uses: ./.github/actions/detect-pipeline-changes
+        with:
+          base-sha: ${{ github.event.before || 'HEAD~1' }}
+          head-sha: ${{ github.sha }}
 
   # ---------------------------------------------------------------------------
   # Wait for CI to succeed (auto-apply gate)


### PR DESCRIPTION
## Problem

Production workflow was not detecting any changes when code was pushed to main because detect-changes was comparing `origin/main...HEAD` (which are the same commit after checkout).

## Root Cause

The detect-pipeline-changes action didn't accept parameters and relied on environment variables. For push events, it tried to use `GITHUB_EVENT_BEFORE` but fell back to `origin/main` which equals `HEAD` after checkout.

## Solution

- Updated detect-pipeline-changes action to accept `base-sha` and `head-sha` inputs
- Production workflow now explicitly passes `github.event.before` as base-sha
- This ensures we compare the previous commit to current commit on push

## Impact

**Before**: 
```
Comparing: origin/main...HEAD
No changed files detected
→ All jobs skipped
```

**After**:
```
Comparing: <previous-commit>...<current-commit>
Changed files detected
→ Relevant jobs execute
```

## Testing

Will verify on merge that:
1. CI workflow runs and detects changes
2. Production workflow detects changes and deploys
3. Kustomization gets updated with new SHA tag

## Related

- Fixes the issue from #23 merge where production workflow completed but skipped all deployment jobs
- Production workflow run that failed: https://github.com/AshleyHollis/yt-summarizer/actions/runs/21093401795