### PR TITLE
fix: correct YAML indentation in transcribe-worker patch

### DIFF
--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -50,13 +50,13 @@ patches:
           spec:
             containers:
               - name: worker
-                  resources:
-                    requests:
-                      cpu: 25m
-                      memory: 128Mi
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
+                resources:
+                  requests:
+                    cpu: 25m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
   - target:
       group: apps
       version: v1


### PR DESCRIPTION
## Summary
- Fixes YAML indentation error in `k8s/overlays/prod/kustomization.yaml`
- The `transcribe-worker` deployment patch had extra spaces before the `resources:` key
- This was causing ArgoCD to fail parsing with error: `unable to parse SM or JSON patch`

## Impact
- **Before**: ArgoCD application `yt-summarizer-prod` showed `ComparisonError` and could not sync
- **After**: Kustomization should parse correctly and allow ArgoCD to deploy production resources

## Testing
- Validated YAML syntax matches other worker patches (api, summarize-worker, etc.)
- Will verify ArgoCD sync succeeds after merge

## Related
- Production environment was returning 404s because ArgoCD couldn't deploy resources
- This blocks production Auth0 testing