### PR TITLE
fix: remove invalid priority-class-patch.yaml reference

### DIFF
--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -123,7 +123,6 @@ patches:
                   limits:
                     cpu: 500m
                     memory: 512Mi
-  - path: patches/priority-class-patch.yaml
 images:
   - 
     name: yt-summarizer-api


### PR DESCRIPTION
## Summary
- Removes invalid reference to `patches/priority-class-patch.yaml` from `k8s/overlays/prod/kustomization.yaml`
- This file doesn't exist and was causing ArgoCD kustomize build to fail

## Root Cause
The kustomization.yaml had a leftover reference to a patch file that was never created:
```yaml
- path: patches/priority-class-patch.yaml  # This file doesn't exist!
```

## Fix
- Removed the invalid patch reference from line 126
- Priority class is already included as a resource (line 12: `priority-class.yaml`)
- Resource limits are defined as inline patches (lines 16-125)

## Error Before Fix
```
Failed to load target state: failed to generate manifest for source 1 of 1: 
rpc error: code = Unknown desc = kustomize build failed
lstat .../k8s/overlays/prod/patches/priority-class-patch.yaml: no such file or directory
```

## Testing
- Validated kustomization builds locally (if possible)
- Will verify ArgoCD sync succeeds after merge

## Related
- Blocks production deployment via ArgoCD
- Related to PR #28 (previous kustomization fix)