### PR TITLE
fix: disable pytest-xdist parallel testing for API tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,11 +335,11 @@ jobs:
         with:
           test-name: API Tests
 
-      - name: Run API tests (parallel)
+      - name: Run API tests
         uses: ./.github/actions/run-pytest
         with:
           working-directory: services/api
-          parallel: 'true'
+          parallel: 'false'
           pytest-args: '-v --tb=short -m "not integration and not live"'
 
       - name: Record tests finish


### PR DESCRIPTION
## Summary

- Disables pytest-xdist parallel test execution for API tests
- Fixes 'no tests ran' error in CI pipeline
- Unblocks CI while root cause is investigated

## Details

Pytest-xdist is failing in CI with the error: `2 workers [0 items]` and `no tests ran in 0.71s`

This appears to be a worker process isolation issue rather than a code problem:
- Tests run fine serially
- Tests work locally
- Same error existed in pre-Phase 4 commits

**Impact:**
- CI tests will now run sequentially instead of in parallel (slightly slower)
- CI pipeline will no longer fail on this error
- Root cause investigation can proceed separately

## Root Cause Investigation (TODO)

Separate work to determine why pytest-xdist workers can't find/run tests:
1. Worker process dependency isolation
2. conftest.py event loop fixture compatibility
3. pytest discovery in isolated processes