### PR TITLE
fix(k8s): override OpenClaw prod image tags

### DIFF
--- a/k8s/overlays/openclaw-prod/kustomization.yaml
+++ b/k8s/overlays/openclaw-prod/kustomization.yaml
@@ -14,10 +14,12 @@ resources:
   - ../prod
 
 images:
-  - name: yt-summarizer-api
+  # The nested ../prod overlay rewrites short image names to ACR names first.
+  # Match those rewritten names here so OpenClaw production receives the new tag.
+  - name: acrytsummprdci.azurecr.io/yt-summarizer-api
     newName: acrytsummprdci.azurecr.io/yt-summarizer-api
     newTag: sha-2a00302
-  - name: yt-summarizer-workers
+  - name: acrytsummprdci.azurecr.io/yt-summarizer-workers
     newName: acrytsummprdci.azurecr.io/yt-summarizer-workers
     newTag: sha-2a00302
 

--- a/scripts/ci/templates/prod-openclaw-kustomization-template.yaml
+++ b/scripts/ci/templates/prod-openclaw-kustomization-template.yaml
@@ -10,10 +10,12 @@ resources:
   - ../prod
 
 images:
-  - name: yt-summarizer-api
+  # The nested ../prod overlay rewrites short image names to ACR names first.
+  # Match those rewritten names here so OpenClaw production receives the new tag.
+  - name: acrytsummprdci.azurecr.io/yt-summarizer-api
     newName: acrytsummprdci.azurecr.io/yt-summarizer-api
     newTag: ${IMAGE_TAG}
-  - name: yt-summarizer-workers
+  - name: acrytsummprdci.azurecr.io/yt-summarizer-workers
     newName: acrytsummprdci.azurecr.io/yt-summarizer-workers
     newTag: ${IMAGE_TAG}
 


### PR DESCRIPTION
## Summary
- match OpenClaw prod image overrides against the ACR image names emitted by the nested prod overlay
- update the generated OpenClaw prod overlay to render sha-2a00302 images

## Validation
- kubectl kustomize k8s/overlays/openclaw-prod renders sha-2a00302 for API and worker images
- python -m pre_commit run --all-files --verbose