### PR TITLE
fix(api): use HTTPS auth callbacks behind tunnel

### DIFF
--- a/services/api/src/api/routes/auth.py
+++ b/services/api/src/api/routes/auth.py
@@ -168,10 +168,66 @@ def _sanitize_return_to(return_to: str, settings: Any) -> str:
     return return_to
 
 
+def _first_header_value(value: str | None) -> str | None:
+    if not value:
+        return None
+    return value.split(",", 1)[0].strip()
+
+
+def _host_name(host: str) -> str:
+    parsed = urlparse(f"//{host}")
+    return (parsed.hostname or host.split(":", 1)[0]).strip("[]").lower()
+
+
+def _is_local_host(host: str) -> bool:
+    hostname = _host_name(host)
+    return hostname in {"localhost", "127.0.0.1", "::1", "testserver"} or hostname.endswith(
+        ".local"
+    )
+
+
+def _forwarded_proto(request: Request) -> str | None:
+    proto = _first_header_value(request.headers.get("X-Forwarded-Proto"))
+    if proto:
+        return proto.lower()
+
+    proto = _first_header_value(request.headers.get("X-Forwarded-Scheme"))
+    if proto:
+        return proto.lower()
+
+    if request.headers.get("X-Forwarded-SSL", "").lower() == "on":
+        return "https"
+
+    forwarded = _first_header_value(request.headers.get("Forwarded"))
+    if forwarded:
+        for part in forwarded.split(";"):
+            key, _, value = part.strip().partition("=")
+            if key.lower() == "proto" and value:
+                return value.strip('"').lower()
+
+    cf_visitor = request.headers.get("CF-Visitor")
+    if cf_visitor:
+        try:
+            scheme = json.loads(cf_visitor).get("scheme")
+            if scheme:
+                return str(scheme).lower()
+        except (TypeError, ValueError):
+            pass
+
+    return None
+
+
 def _build_callback_url(request: Request) -> str:
-    # Check for X-Forwarded-Proto header to handle reverse proxy HTTPS
-    proto = request.headers.get("X-Forwarded-Proto", "http")
-    host = request.headers.get("Host", str(request.base_url.netloc))
+    host = _first_header_value(request.headers.get("X-Forwarded-Host"))
+    if not host:
+        host = request.headers.get("Host", str(request.base_url.netloc))
+
+    proto = _forwarded_proto(request)
+    if not proto:
+        # Cloudflare Tunnel terminates TLS before forwarding to the in-cluster HTTP service.
+        # If no proxy header survives, public hosts still need the external HTTPS URL for Auth0.
+        proto = "http" if _is_local_host(host) else "https"
+
     # Use /auth/callback as the primary callback URL
     return f"{proto}://{host}/api/auth/callback"
 

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -1,6 +1,7 @@
 """Tests for auth endpoints."""
 
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi.testclient import TestClient
@@ -45,6 +46,66 @@ def test_login_redirects_to_auth0():
         # Should redirect to Auth0 domain
         location = response.headers.get("location", "")
         assert "authorize" in location or "auth0.com" in location
+
+
+def _fake_auth_settings():
+    class FakeAuth:
+        domain = "test.auth0.com"
+        client_id = "test-client-id"
+        client_secret = "test-client-secret"
+        audience = None
+        session_secret = "test-session-secret-at-least-32-chars"
+        session_ttl_seconds = 86400
+        default_return_to = "http://localhost:3000"
+        session_cookie_name = "session"
+
+    class FakeAPI:
+        cors_origins = [
+            "http://localhost:3000",
+            "https://proud-hill-0940e7300.6.azurestaticapps.net",
+        ]
+        cors_origin_regex = None
+
+    class FakeSettings:
+        api = FakeAPI()
+        auth = FakeAuth()
+
+    return FakeSettings()
+
+
+def _login_redirect_uri(headers: dict[str, str], return_to: str) -> str:
+    with patch("api.routes.auth.get_settings", return_value=_fake_auth_settings()):
+        response = client.get(
+            "/api/auth/login",
+            params={"returnTo": return_to},
+            headers=headers,
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    return parse_qs(urlparse(location).query)["redirect_uri"][0]
+
+
+@pytest.mark.unit
+def test_login_uses_https_callback_for_public_tunnel_host_without_forwarded_proto():
+    """Cloudflare Tunnel may forward to the service over HTTP without X-Forwarded-Proto."""
+    redirect_uri = _login_redirect_uri(
+        headers={"Host": "api-ytsummarizer.ashleyhollis.com"},
+        return_to="https://proud-hill-0940e7300.6.azurestaticapps.net",
+    )
+
+    assert redirect_uri == "https://api-ytsummarizer.ashleyhollis.com/api/auth/callback"
+
+
+@pytest.mark.unit
+def test_login_keeps_http_callback_for_localhost_without_forwarded_proto():
+    redirect_uri = _login_redirect_uri(
+        headers={"Host": "localhost:8000"},
+        return_to="http://localhost:3000",
+    )
+
+    assert redirect_uri == "http://localhost:8000/api/auth/callback"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- infer HTTPS callback URLs for public/proxied hosts when no forwarded proto header survives
- preserve HTTP callback URLs for localhost/testserver development requests
- add regression tests for the Cloudflare Tunnel/Auth0 callback mismatch

## Validation
- `..\..\.venv\Scripts\python.exe -m pytest tests/test_auth.py -v --tb=short`
- `..\..\.venv\Scripts\python.exe -m pytest tests/ -m "not integration and not live" -v --tb=short`
- `python -m pre_commit run --all-files --verbose`

## Context
After the OpenClaw migration, the public API login redirect generated `redirect_uri=http://api-ytsummarizer.ashleyhollis.com/api/auth/callback`. Auth0 correctly allows only the HTTPS callback, so admin E2E auth failed with callback URL mismatch.