### PR TITLE
fix(api): force HTTPS auth callbacks for public hosts

### DIFF
--- a/services/api/src/api/routes/auth.py
+++ b/services/api/src/api/routes/auth.py
@@ -223,10 +223,12 @@ def _build_callback_url(request: Request) -> str:
         host = request.headers.get("Host", str(request.base_url.netloc))
 
     proto = _forwarded_proto(request)
-    if not proto:
+    if not _is_local_host(host):
         # Cloudflare Tunnel terminates TLS before forwarding to the in-cluster HTTP service.
-        # If no proxy header survives, public hosts still need the external HTTPS URL for Auth0.
-        proto = "http" if _is_local_host(host) else "https"
+        # Auth0 needs the external HTTPS callback, not the proxy's internal HTTP hop.
+        proto = "https"
+    elif not proto:
+        proto = "http"
 
     # Use /auth/callback as the primary callback URL
     return f"{proto}://{host}/api/auth/callback"

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -99,6 +99,20 @@ def test_login_uses_https_callback_for_public_tunnel_host_without_forwarded_prot
 
 
 @pytest.mark.unit
+def test_login_uses_https_callback_for_public_tunnel_host_with_internal_http_proto():
+    """Cloudflare Tunnel may report the internal hop as HTTP after terminating TLS."""
+    redirect_uri = _login_redirect_uri(
+        headers={
+            "Host": "api-ytsummarizer.ashleyhollis.com",
+            "X-Forwarded-Proto": "http",
+        },
+        return_to="https://proud-hill-0940e7300.6.azurestaticapps.net",
+    )
+
+    assert redirect_uri == "https://api-ytsummarizer.ashleyhollis.com/api/auth/callback"
+
+
+@pytest.mark.unit
 def test_login_keeps_http_callback_for_localhost_without_forwarded_proto():
     redirect_uri = _login_redirect_uri(
         headers={"Host": "localhost:8000"},


### PR DESCRIPTION
## Summary
- force Auth0 callback URLs to HTTPS for non-local hosts even when the proxy reports its internal hop as HTTP
- keep local/test hosts on HTTP when no HTTPS proxy is involved
- add a regression test for Cloudflare Tunnel sending X-Forwarded-Proto: http

## Validation
- ..\..\.venv\Scripts\python.exe -m pytest tests/test_auth.py -v --tb=short
- ..\..\.venv\Scripts\python.exe -m pytest tests/ -m "not integration and not live" -v --tb=short
- python -m pre_commit run --all-files --verbose
