### PR TITLE
Fix OpenClaw migration runner and library query loading

### DIFF
--- a/k8s/base-preview/migration-job.yaml
+++ b/k8s/base-preview/migration-job.yaml
@@ -37,9 +37,10 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eu
               echo "Starting database migrations..."
-              cd /app
-              alembic upgrade head
+              cd /app/shared
+              python scripts/run_migrations.py
               echo "Migrations completed successfully!"
           env:
             - name: DATABASE_URL

--- a/k8s/base/migration-job.yaml
+++ b/k8s/base/migration-job.yaml
@@ -37,9 +37,10 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eu
               echo "Starting database migrations..."
-              cd /app
-              alembic upgrade head
+              cd /app/shared
+              python scripts/run_migrations.py
               echo "Migrations completed successfully!"
           env:
             - name: DATABASE_URL

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -69,6 +69,9 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy application code
 COPY services/shared/shared/ /app/shared/shared/
+COPY services/shared/alembic.ini /app/shared/alembic.ini
+COPY services/shared/alembic/ /app/shared/alembic/
+COPY services/shared/scripts/ /app/shared/scripts/
 COPY services/api/src/ ./src/
 
 # Set Python path

--- a/services/api/src/api/services/job_service.py
+++ b/services/api/src/api/services/job_service.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import noload
 
 # Import shared modules
 try:
@@ -166,10 +167,11 @@ class JobService:
         Returns:
             VideoJobsProgress or None if video not found.
         """
-        # Check video exists
-        video_result = await self.session.execute(select(Video).where(Video.video_id == video_id))
-        video = video_result.scalar_one_or_none()
-        if not video:
+        # Check video exists without loading selectin relationships like transcript segments.
+        video_result = await self.session.execute(
+            select(Video.video_id).where(Video.video_id == video_id)
+        )
+        if video_result.scalar_one_or_none() is None:
             return None
 
         # Get all jobs for this video
@@ -338,9 +340,9 @@ class JobService:
 
             # Get video info
             video_result = await self.session.execute(
-                select(Video).where(Video.video_id == job.video_id)
+                select(Video.youtube_video_id).where(Video.video_id == job.video_id)
             )
-            video = video_result.scalar_one_or_none()
+            youtube_video_id = video_result.scalar_one_or_none()
 
             queue_client.send_message(
                 queue_name,
@@ -348,7 +350,7 @@ class JobService:
                     {
                         "job_id": str(job.job_id),
                         "video_id": str(job.video_id),
-                        "youtube_video_id": video.youtube_video_id if video else "",
+                        "youtube_video_id": youtube_video_id or "",
                         "correlation_id": correlation_id,
                         "retry_count": job.retry_count,
                     }
@@ -430,7 +432,16 @@ class JobService:
             VideoProcessingHistory or None if video not found.
         """
         # Get video
-        video_result = await self.session.execute(select(Video).where(Video.video_id == video_id))
+        video_result = await self.session.execute(
+            select(Video)
+            .options(
+                noload(Video.channel),
+                noload(Video.segments),
+                noload(Video.artifacts),
+                noload(Video.jobs),
+            )
+            .where(Video.video_id == video_id)
+        )
         video = video_result.scalar_one_or_none()
         if not video:
             return None

--- a/services/api/src/api/services/library_service.py
+++ b/services/api/src/api/services/library_service.py
@@ -5,11 +5,11 @@ from uuid import UUID
 
 from sqlalchemy import Select, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import noload, selectinload
+from sqlalchemy.orm import contains_eager, noload, selectinload
 
 # Import shared modules
 try:
-    from shared.blob.client import SUMMARIES_CONTAINER, BlobClient
+    from shared.blob.client import SUMMARIES_CONTAINER, get_blob_client
     from shared.db.models import (
         Artifact,
         Channel,
@@ -34,7 +34,7 @@ except ImportError as e:
     Segment = Any
     Video = Any
     VideoFacet = Any
-    BlobClient = None
+    get_blob_client = None
     SUMMARIES_CONTAINER = "summaries"
 
     def get_logger(name):
@@ -85,11 +85,18 @@ class LibraryService:
         Returns:
             SQLAlchemy select query.
         """
-        query = select(Video).options(
-            selectinload(Video.channel),
-            noload(Video.segments),
-            noload(Video.artifacts),
-            noload(Video.jobs),
+        query = (
+            select(Video)
+            .join(Video.channel)
+            .options(
+                contains_eager(Video.channel).options(
+                    noload(Channel.videos),
+                    noload(Channel.batches),
+                ),
+                noload(Video.segments),
+                noload(Video.artifacts),
+                noload(Video.jobs),
+            )
         )
 
         # Apply filters
@@ -212,38 +219,51 @@ class LibraryService:
         Returns:
             Video detail response or None if not found.
         """
+        segment_count_subquery = (
+            select(func.count())
+            .where(Segment.video_id == Video.video_id)
+            .correlate(Video)
+            .scalar_subquery()
+        )
+        relationship_count_subquery = (
+            select(func.count())
+            .where(
+                or_(
+                    Relationship.source_video_id == Video.video_id,
+                    Relationship.target_video_id == Video.video_id,
+                )
+            )
+            .correlate(Video)
+            .scalar_subquery()
+        )
+
         query = (
-            select(Video)
+            select(
+                Video,
+                segment_count_subquery.label("segment_count"),
+                relationship_count_subquery.label("relationship_count"),
+            )
+            .join(Video.channel)
             .options(
-                selectinload(Video.channel),
+                contains_eager(Video.channel).options(
+                    noload(Channel.videos),
+                    noload(Channel.batches),
+                ),
+                selectinload(Video.artifacts),
                 noload(Video.segments),
-                noload(Video.artifacts),
                 noload(Video.jobs),
             )
             .where(Video.video_id == video_id)
         )
         result = await self.session.execute(query)
-        video = result.scalar_one_or_none()
+        row = result.one_or_none()
 
-        if not video:
+        if not row:
             return None
 
-        # Get segment count
-        segment_count_result = await self.session.execute(
-            select(func.count()).where(Segment.video_id == video_id)
-        )
-        segment_count = segment_count_result.scalar() or 0
-
-        # Get relationship count
-        relationship_count_result = await self.session.execute(
-            select(func.count()).where(
-                or_(
-                    Relationship.source_video_id == video_id,
-                    Relationship.target_video_id == video_id,
-                )
-            )
-        )
-        relationship_count = relationship_count_result.scalar() or 0
+        video, segment_count, relationship_count = row
+        segment_count = segment_count or 0
+        relationship_count = relationship_count or 0
 
         # Get facets
         video_facets = await self._get_video_facets([video_id])
@@ -279,9 +299,9 @@ class LibraryService:
                 transcript_artifact = artifact_info
 
         # Fetch summary content from blob storage if available
-        if summary_blob_name and BlobClient is not None:
+        if summary_blob_name and get_blob_client is not None:
             try:
-                blob_client = BlobClient()
+                blob_client = get_blob_client()
                 summary_bytes = blob_client.download_blob(SUMMARIES_CONTAINER, summary_blob_name)
                 summary_text = summary_bytes.decode("utf-8")
             except Exception as e:
@@ -391,7 +411,7 @@ class LibraryService:
         Returns:
             Paginated list of channel cards.
         """
-        query = select(Channel)
+        query = select(Channel).options(noload(Channel.videos), noload(Channel.batches))
 
         if search:
             query = query.where(Channel.name.ilike(f"%{search}%"))
@@ -438,7 +458,11 @@ class LibraryService:
         Returns:
             Channel detail response or None if not found.
         """
-        result = await self.session.execute(select(Channel).where(Channel.channel_id == channel_id))
+        result = await self.session.execute(
+            select(Channel)
+            .options(noload(Channel.videos), noload(Channel.batches))
+            .where(Channel.channel_id == channel_id)
+        )
         channel = result.scalar_one_or_none()
 
         if not channel:
@@ -601,6 +625,7 @@ class LibraryService:
 
         result = await self.session.execute(
             select(VideoFacet.video_id, Facet)
+            .options(noload(Facet.video_facets))
             .join(Facet, VideoFacet.facet_id == Facet.facet_id)
             .where(VideoFacet.video_id.in_(video_ids))
         )
@@ -650,6 +675,7 @@ class LibraryService:
         """
         result = await self.session.execute(
             select(Facet, func.count().label("count"))
+            .options(noload(Facet.video_facets))
             .join(VideoFacet, Facet.facet_id == VideoFacet.facet_id)
             .join(Video, VideoFacet.video_id == Video.video_id)
             .where(Video.channel_id == channel_id)

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -45,6 +45,7 @@ def mock_session():
     mock_result.scalars.return_value = mock_scalars
     mock_result.scalar.return_value = 0  # For count queries
     mock_result.scalar_one_or_none.return_value = None
+    mock_result.one_or_none.return_value = None
     mock_result.fetchone.return_value = None
     mock_result.fetchall.return_value = []
 

--- a/services/api/tests/test_library_service.py
+++ b/services/api/tests/test_library_service.py
@@ -192,7 +192,7 @@ class TestGetVideoDetailSummaryFetching:
 
         # For the video query (first call)
         mock_video_result = MagicMock()
-        mock_video_result.scalar_one_or_none.return_value = video
+        mock_video_result.one_or_none.return_value = (video, 0, 0)
 
         # For count queries (segment_count, relationship_count)
         mock_count_result = MagicMock()
@@ -214,10 +214,10 @@ class TestGetVideoDetailSummaryFetching:
         expected_blob_name = f"{video_id}/{youtube_video_id}_summary.md"
         mock_summary_content = b"# Test Summary\n\nThis is the summary content."
 
-        with patch("api.services.library_service.BlobClient") as MockBlobClient:
+        with patch("api.services.library_service.get_blob_client") as mock_get_blob_client:
             mock_blob_instance = MagicMock()
             mock_blob_instance.download_blob.return_value = mock_summary_content
-            MockBlobClient.return_value = mock_blob_instance
+            mock_get_blob_client.return_value = mock_blob_instance
 
             from api.services.library_service import LibraryService
 
@@ -245,15 +245,15 @@ class TestGetVideoDetailSummaryFetching:
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = video
+        mock_result.one_or_none.return_value = (video, 0, 0)
         mock_session.execute = AsyncMock(return_value=mock_result)
 
         mock_summary_content = b"# Test Summary\n\nThis is the summary content."
 
-        with patch("api.services.library_service.BlobClient") as MockBlobClient:
+        with patch("api.services.library_service.get_blob_client") as mock_get_blob_client:
             mock_blob_instance = MagicMock()
             mock_blob_instance.download_blob.return_value = mock_summary_content
-            MockBlobClient.return_value = mock_blob_instance
+            mock_get_blob_client.return_value = mock_blob_instance
 
             from api.services.library_service import LibraryService
 
@@ -273,13 +273,13 @@ class TestGetVideoDetailSummaryFetching:
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = video
+        mock_result.one_or_none.return_value = (video, 0, 0)
         mock_session.execute = AsyncMock(return_value=mock_result)
 
-        with patch("api.services.library_service.BlobClient") as MockBlobClient:
+        with patch("api.services.library_service.get_blob_client") as mock_get_blob_client:
             mock_blob_instance = MagicMock()
             mock_blob_instance.download_blob.side_effect = Exception("BlobNotFound")
-            MockBlobClient.return_value = mock_blob_instance
+            mock_get_blob_client.return_value = mock_blob_instance
 
             from api.services.library_service import LibraryService
 
@@ -319,10 +319,10 @@ class TestGetVideoDetailSummaryFetching:
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = video
+        mock_result.one_or_none.return_value = (video, 0, 0)
         mock_session.execute = AsyncMock(return_value=mock_result)
 
-        with patch("api.services.library_service.BlobClient") as MockBlobClient:
+        with patch("api.services.library_service.get_blob_client") as mock_get_blob_client:
             from api.services.library_service import LibraryService
 
             service = LibraryService(mock_session)
@@ -331,7 +331,7 @@ class TestGetVideoDetailSummaryFetching:
             result = await service.get_video_detail(str(video_id))
 
             # Should not have called blob client at all
-            MockBlobClient.return_value.download_blob.assert_not_called()
+            mock_get_blob_client.assert_not_called()
 
             assert result.summary is None, (
                 "Summary should be None when video has no summary artifact"
@@ -394,15 +394,15 @@ class TestCompletedStatusValidation:
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = video
+        mock_result.one_or_none.return_value = (video, 0, 0)
         mock_session.execute = AsyncMock(return_value=mock_result)
 
         expected_summary = "# Summary\n\nThis is the actual summary content."
 
-        with patch("api.services.library_service.BlobClient") as MockBlobClient:
+        with patch("api.services.library_service.get_blob_client") as mock_get_blob_client:
             mock_blob_instance = MagicMock()
             mock_blob_instance.download_blob.return_value = expected_summary.encode("utf-8")
-            MockBlobClient.return_value = mock_blob_instance
+            mock_get_blob_client.return_value = mock_blob_instance
 
             from api.services.library_service import LibraryService
 

--- a/services/shared/scripts/run_migrations.py
+++ b/services/shared/scripts/run_migrations.py
@@ -1,0 +1,199 @@
+"""Run Alembic migrations with a guarded baseline for existing production schemas."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import quote_plus
+
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
+
+from alembic import command
+
+BASELINE_REVISION = "014"
+ALEMBIC_VERSION_TABLE = "alembic_version"
+
+BASELINE_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "Channels": ("channel_id", "youtube_channel_id"),
+    "Videos": ("video_id", "processing_status"),
+    "Batches": ("batch_id",),
+    "BatchItems": ("batch_item_id",),
+    "Jobs": (
+        "job_id",
+        "correlation_id",
+        "next_retry_at",
+        "estimated_wait_seconds",
+        "quota_status",
+        "user_id",
+    ),
+    "Artifacts": ("artifact_id",),
+    "Segments": ("segment_id", "Embedding"),
+    "Relationships": ("relationship_id",),
+    "Facets": ("facet_id",),
+    "VideoFacets": ("video_facet_id",),
+    "ChatThreads": ("thread_id", "last_run_id", "scope_json", "ai_settings_json"),
+    "JobHistory": (
+        "history_id",
+        "queued_at",
+        "wait_seconds",
+        "enforced_delay_seconds",
+        "estimated_wait_seconds",
+    ),
+    "proxy_request_logs": ("id", "job_id", "created_at"),
+    "Users": ("user_id", "auth0_id"),
+    "UsageRecords": ("usage_id",),
+    "ExpediteRequests": ("request_id",),
+}
+
+
+def _convert_ado_connection_string(ado_string: str) -> str:
+    parts = {}
+    for part in ado_string.split(";"):
+        if "=" in part:
+            key, value = part.split("=", 1)
+            parts[key.strip().lower()] = value.strip()
+
+    server = parts.get("server", parts.get("data source", "localhost"))
+    database = parts.get("database", parts.get("initial catalog", ""))
+    user = parts.get("user id", parts.get("uid", "sa"))
+    password = quote_plus(parts.get("password", parts.get("pwd", "")))
+
+    if server.lower().startswith("tcp:"):
+        server = server[4:]
+
+    if "," in server:
+        host, port = server.split(",", 1)
+    elif ":" in server:
+        host, port = server.split(":", 1)
+    else:
+        host, port = server, "1433"
+
+    return (
+        f"mssql+pyodbc://{user}:{password}@{host},{port}/{database}"
+        "?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+    )
+
+
+def _database_url() -> str:
+    url = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("ConnectionStrings__ytsummarizer")
+        or os.environ.get("ConnectionStrings__sql")
+    )
+    if not url:
+        raise RuntimeError(
+            "Database connection string not found. Set DATABASE_URL, "
+            "ConnectionStrings__ytsummarizer, or ConnectionStrings__sql."
+        )
+
+    if "Server=" in url and ";" in url:
+        return _convert_ado_connection_string(url)
+    if url.startswith("mssql+aioodbc://"):
+        return url.replace("mssql+aioodbc://", "mssql+pyodbc://", 1)
+    if "://" not in url:
+        return (
+            f"mssql+pyodbc://{url}?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+        )
+    return url
+
+
+def _table_exists(conn: Connection, table_name: str) -> bool:
+    result = conn.execute(
+        text(
+            """
+            SELECT COUNT(*)
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME = :table_name
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return bool(result.scalar())
+
+
+def _column_exists(conn: Connection, table_name: str, column_name: str) -> bool:
+    result = conn.execute(
+        text(
+            """
+            SELECT COUNT(*)
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = :table_name AND COLUMN_NAME = :column_name
+            """
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return bool(result.scalar())
+
+
+def _known_app_tables(conn: Connection) -> set[str]:
+    result = conn.execute(
+        text(
+            """
+            SELECT TABLE_NAME
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_TYPE = 'BASE TABLE'
+            """
+        )
+    )
+    existing = set(result.scalars())
+    return existing.intersection(BASELINE_REQUIREMENTS.keys())
+
+
+def _missing_baseline_objects(conn: Connection) -> list[str]:
+    missing: list[str] = []
+    for table_name, columns in BASELINE_REQUIREMENTS.items():
+        if not _table_exists(conn, table_name):
+            missing.append(f"{table_name}.*")
+            continue
+        for column_name in columns:
+            if not _column_exists(conn, table_name, column_name):
+                missing.append(f"{table_name}.{column_name}")
+    return missing
+
+
+def _alembic_config() -> Config:
+    shared_root = Path(__file__).resolve().parents[1]
+    config = Config(str(shared_root / "alembic.ini"))
+    config.set_main_option("script_location", str(shared_root / "alembic"))
+    return config
+
+
+def main() -> None:
+    engine = create_engine(_database_url(), pool_pre_ping=True)
+    config = _alembic_config()
+    stamp_revision: str | None = None
+
+    try:
+        with engine.begin() as conn:
+            has_version_table = _table_exists(conn, ALEMBIC_VERSION_TABLE)
+            known_tables = _known_app_tables(conn)
+            if not has_version_table and known_tables:
+                missing = _missing_baseline_objects(conn)
+                if missing:
+                    formatted = ", ".join(missing)
+                    raise RuntimeError(
+                        "Database is unversioned and does not match the expected "
+                        f"{BASELINE_REVISION} baseline. Missing: {formatted}"
+                    )
+
+                print(
+                    "Existing unversioned schema matches baseline "
+                    f"{BASELINE_REVISION}; stamping Alembic."
+                )
+                stamp_revision = BASELINE_REVISION
+            elif not has_version_table:
+                print("No existing application schema detected; running migrations from scratch.")
+
+        if stamp_revision:
+            command.stamp(config, stamp_revision)
+
+        command.upgrade(config, "head")
+        print("Alembic migrations completed successfully.")
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ship Alembic config/scripts in the API image and run a guarded migration runner from the K8s migration Job
- safely baseline existing unversioned production schemas at revision 014 before applying head migrations
- avoid accidental eager loading of transcript/channel relationship collections in library and job progress queries

## Validation
- Applied live prod schema hotfix: alembic_version=015 and Segments.label exists
- `uv run --extra dev ruff check ../api/src/api/services/job_service.py ../api/src/api/services/library_service.py scripts/run_migrations.py`
- `python -m py_compile services/shared/scripts/run_migrations.py services/api/src/api/services/job_service.py services/api/src/api/services/library_service.py`
- `kubectl kustomize k8s/overlays/openclaw-prod`
- focused API tests: `tests/test_jobs.py::TestVideoJobsProgress`, `tests/test_library.py::{TestListVideos,TestListChannels,TestGetVideoDetail}`: 22 passed
- `./scripts/run-tests.ps1 -Component shared`: 39 passed

## Known local test environment issues
- `./scripts/run-tests.ps1 -Component api` has 6 auth integration failures because local Auth0/session env vars are not configured
- full/e2e runner timed out locally because localhost:3000 is currently an unrelated app, so Playwright was not pointed at the YT Summarizer UI