### PR TITLE
Fix OpenClaw page latency hot spots

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -27,6 +27,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Azure Login via OIDC
+        if: (vars.K8S_PLATFORM || 'aks') == 'openclaw'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Load Cloudflare API token from Key Vault
+        id: cloudflare-token
+        if: (vars.K8S_PLATFORM || 'aks') == 'openclaw'
+        shell: bash
+        run: |
+          token="$(az keyvault secret show \
+            --vault-name "${{ vars.KEY_VAULT_NAME || 'kv-ytsumm-prd-ci' }}" \
+            --name cloudflare-api-token \
+            --query value \
+            --output tsv)"
+          echo "::add-mask::${token}"
+          echo "token=${token}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete OpenClaw preview DNS
+        if: (vars.K8S_PLATFORM || 'aks') == 'openclaw'
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ steps.cloudflare-token.outputs.token }}
+        run: |
+          scripts/workflows/openclaw-preview-dns.sh \
+            delete \
+            "api-pr-${{ github.event.pull_request.number }}.ashleyhollis.com"
+
       - name: Close SWA staging environment
         id: swa-cleanup
         uses: AshleyHollis/shared-infra/.github/actions/close-swa-environment@v1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -78,7 +78,7 @@ env:
   ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER || 'acrytsummprdci.azurecr.io' }}
   K8S_PLATFORM: ${{ vars.K8S_PLATFORM || 'aks' }}
   PREVIEW_NAMESPACE_PREFIX: "preview-pr-"
-  APPS_BASE_DOMAIN: "yt-summarizer.apps.ashleyhollis.com"
+  APPS_BASE_DOMAIN: ${{ (vars.K8S_PLATFORM || 'aks') == 'openclaw' && 'ashleyhollis.com' || 'yt-summarizer.apps.ashleyhollis.com' }}
   ARGOCD_SYNC_TIMEOUT: "180"
   KUSTOMIZE_OVERLAY_PREVIEW: "k8s/overlays/preview"
   MAX_PREVIEWS: 3

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -430,6 +430,50 @@ jobs:
           echo "❌ Timed out waiting for AKS API server DNS to resolve."
           exit 1
 
+  ensure-openclaw-preview-dns:
+    name: Ensure OpenClaw Preview DNS
+    runs-on: ubuntu-latest
+    needs: [get-ingress, check-concurrency, detect-changes]
+    if: |
+      always() && !cancelled() &&
+      (github.event_name != 'workflow_dispatch' || inputs.run_preview == true) &&
+      needs.detect-changes.outputs.needs_backend_deployment == 'true' &&
+      needs.check-concurrency.result == 'success' &&
+      needs.check-concurrency.outputs.can_deploy == 'true' &&
+      needs.get-ingress.result == 'success' &&
+      (vars.K8S_PLATFORM || 'aks') == 'openclaw'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Azure Login via OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Load Cloudflare API token from Key Vault
+        id: cloudflare-token
+        shell: bash
+        run: |
+          token="$(az keyvault secret show \
+            --vault-name "${{ vars.KEY_VAULT_NAME || 'kv-ytsumm-prd-ci' }}" \
+            --name cloudflare-api-token \
+            --query value \
+            --output tsv)"
+          echo "::add-mask::${token}"
+          echo "token=${token}" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert OpenClaw preview DNS
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ steps.cloudflare-token.outputs.token }}
+        run: |
+          scripts/workflows/openclaw-preview-dns.sh \
+            upsert \
+            "${{ needs.get-ingress.outputs.preview_host }}"
+
   # ===========================================================================
   # PHASE 4B: SYNC ARGOCD MANIFESTS
   # ===========================================================================
@@ -619,8 +663,16 @@ jobs:
       needs.check-concurrency.result == 'success' &&
       needs.check-concurrency.outputs.can_deploy == 'true' &&
       needs.update-overlay.result == 'success' &&
+      needs.ensure-openclaw-preview-dns.result == 'success' &&
       (vars.K8S_PLATFORM || 'aks') == 'openclaw'
-    needs: [update-overlay, check-concurrency, get-ingress, detect-changes]
+    needs:
+      [
+        update-overlay,
+        ensure-openclaw-preview-dns,
+        check-concurrency,
+        get-ingress,
+        detect-changes,
+      ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -941,6 +993,7 @@ jobs:
       - update-overlay
       - verify-deployment
       - verify-openclaw-health
+      - ensure-openclaw-preview-dns
       - deploy-frontend-preview
       - e2e-tests
       - get-ingress
@@ -987,6 +1040,7 @@ jobs:
             echo "- Concurrency gate: ${{ needs.check-concurrency.outputs.can_deploy || 'n/a' }}"
             echo "- Overlay update: ${{ needs.update-overlay.result }}"
             echo "- Backend verify: ${{ needs.verify-deployment.result }}"
+            echo "- OpenClaw DNS: ${{ needs.ensure-openclaw-preview-dns.result }}"
             echo "- OpenClaw health verify: ${{ needs.verify-openclaw-health.result }}"
             echo "- Frontend deploy: ${{ needs.deploy-frontend-preview.result }}"
             echo "- E2E tests: ${{ needs.e2e-tests.result }}"

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -147,6 +147,8 @@ variable "auth0_allowed_callback_urls" {
     "https://api.yt-summarizer.apps.ashleyhollis.com/api/auth/callback/auth0",
     "https://api-stg.yt-summarizer.apps.ashleyhollis.com/api/auth/callback",
     "https://api-stg.yt-summarizer.apps.ashleyhollis.com/api/auth/callback/auth0",
+    "https://api-pr-*.ashleyhollis.com/api/auth/callback",
+    "https://api-pr-*.ashleyhollis.com/api/auth/callback/auth0",
     "https://api-pr-*.yt-summarizer.apps.ashleyhollis.com/api/auth/callback",
     "https://api-pr-*.yt-summarizer.apps.ashleyhollis.com/api/auth/callback/auth0",
     "http://localhost:3000/api/auth/callback",
@@ -191,6 +193,8 @@ variable "auth0_preview_allowed_callback_urls" {
   description = "Allowed Auth0 callback URLs for preview environments"
   type        = list(string)
   default = [
+    "https://api-pr-*.ashleyhollis.com/api/auth/callback",
+    "https://api-pr-*.ashleyhollis.com/api/auth/callback/auth0",
     "https://api-pr-*.yt-summarizer.apps.ashleyhollis.com/api/auth/callback",
     "https://api-pr-*.yt-summarizer.apps.ashleyhollis.com/api/auth/callback/auth0",
     "https://*.azurestaticapps.net/api/auth/callback",

--- a/scripts/ci/templates/preview-openclaw-kustomization-template.yaml
+++ b/scripts/ci/templates/preview-openclaw-kustomization-template.yaml
@@ -84,7 +84,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/parentRefs/0/sectionName
-        value: http-yt-summarizer
+        value: http-yt-summarizer-preview
       - op: replace
         path: /spec/hostnames/0
         value: "${PREVIEW_HOST}"

--- a/scripts/workflows/openclaw-preview-dns.sh
+++ b/scripts/workflows/openclaw-preview-dns.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:?Usage: openclaw-preview-dns.sh <upsert|delete> <hostname>}"
+HOSTNAME="${2:?Usage: openclaw-preview-dns.sh <upsert|delete> <hostname>}"
+
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+
+ZONE_NAME="${CLOUDFLARE_ZONE_NAME:-ashleyhollis.com}"
+TARGET_RECORD="${CLOUDFLARE_TUNNEL_TARGET_RECORD:-api-ytsummarizer.ashleyhollis.com}"
+API_BASE="https://api.cloudflare.com/client/v4"
+
+cf_get() {
+  local url="$1"
+  shift
+  curl -fsS \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "$url" \
+    "$@"
+}
+
+cf_write() {
+  local method="$1"
+  local url="$2"
+  local body="$3"
+  curl -fsS \
+    -X "$method" \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "$body" \
+    "$url"
+}
+
+zone_response="$(cf_get "${API_BASE}/zones" --get --data-urlencode "name=${ZONE_NAME}")"
+zone_id="$(jq -r '.result[0].id // empty' <<<"${zone_response}")"
+if [[ -z "${zone_id}" ]]; then
+  echo "::error::Cloudflare zone not found: ${ZONE_NAME}"
+  exit 1
+fi
+
+record_response="$(cf_get "${API_BASE}/zones/${zone_id}/dns_records" \
+  --get \
+  --data-urlencode "name=${HOSTNAME}" \
+  --data-urlencode "type=CNAME")"
+record_id="$(jq -r '.result[0].id // empty' <<<"${record_response}")"
+
+if [[ "${MODE}" == "delete" ]]; then
+  if [[ -z "${record_id}" ]]; then
+    echo "No Cloudflare DNS record found for ${HOSTNAME}; nothing to delete."
+    exit 0
+  fi
+
+  delete_response="$(cf_write DELETE "${API_BASE}/zones/${zone_id}/dns_records/${record_id}" "{}")"
+  if [[ "$(jq -r '.success' <<<"${delete_response}")" != "true" ]]; then
+    echo "::error::Failed to delete Cloudflare DNS record for ${HOSTNAME}: $(jq -c '.errors' <<<"${delete_response}")"
+    exit 1
+  fi
+
+  echo "Deleted Cloudflare DNS record for ${HOSTNAME}."
+  exit 0
+fi
+
+if [[ "${MODE}" != "upsert" ]]; then
+  echo "::error::Unsupported mode: ${MODE}"
+  exit 1
+fi
+
+target_response="$(cf_get "${API_BASE}/zones/${zone_id}/dns_records" \
+  --get \
+  --data-urlencode "name=${TARGET_RECORD}" \
+  --data-urlencode "type=CNAME")"
+target_content="$(jq -r '.result[0].content // empty' <<<"${target_response}")"
+if [[ -z "${target_content}" ]]; then
+  echo "::error::Cloudflare tunnel target record not found: ${TARGET_RECORD}"
+  exit 1
+fi
+
+body="$(jq -nc \
+  --arg name "${HOSTNAME}" \
+  --arg content "${target_content}" \
+  '{
+    type: "CNAME",
+    name: $name,
+    content: $content,
+    ttl: 1,
+    proxied: true,
+    comment: "Managed by yt-summarizer preview workflow"
+  }')"
+
+if [[ -n "${record_id}" ]]; then
+  response="$(cf_write PUT "${API_BASE}/zones/${zone_id}/dns_records/${record_id}" "${body}")"
+  action="Updated"
+else
+  response="$(cf_write POST "${API_BASE}/zones/${zone_id}/dns_records" "${body}")"
+  action="Created"
+fi
+
+if [[ "$(jq -r '.success' <<<"${response}")" != "true" ]]; then
+  echo "::error::Failed to upsert Cloudflare DNS record for ${HOSTNAME}: $(jq -c '.errors' <<<"${response}")"
+  exit 1
+fi
+
+echo "${action} Cloudflare DNS record ${HOSTNAME} -> ${target_content}."

--- a/services/api/src/api/routes/videos.py
+++ b/services/api/src/api/routes/videos.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import PlainTextResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Import shared modules
@@ -11,11 +12,13 @@ try:
     from shared.blob.client import (
         SUMMARIES_CONTAINER,
         TRANSCRIPTS_CONTAINER,
+        extract_blob_name_from_uri,
         get_blob_client,
         get_summary_blob_path,
         get_transcript_blob_path,
     )
     from shared.db.connection import get_session
+    from shared.db.models import Artifact
 except ImportError:
     # Fallback for development
     async def get_session():
@@ -30,6 +33,10 @@ except ImportError:
     def get_summary_blob_path(channel_name: str, youtube_video_id: str) -> str:
         raise NotImplementedError("Blob path helper not available")
 
+    def extract_blob_name_from_uri(blob_uri: str, container_name: str) -> str:
+        raise NotImplementedError("Blob URI helper not available")
+
+    Artifact = None
     TRANSCRIPTS_CONTAINER = "transcripts"
     SUMMARIES_CONTAINER = "summaries"
 
@@ -51,6 +58,28 @@ router = APIRouter(prefix="/api/v1/videos", tags=["Videos"])
 def get_video_service(session: AsyncSession = Depends(get_session)) -> VideoService:
     """Dependency to get video service."""
     return VideoService(session)
+
+
+async def get_artifact_blob_name(
+    session: AsyncSession,
+    video_id: UUID,
+    artifact_type: str,
+    container_name: str,
+) -> str | None:
+    """Get the blob name recorded for a video artifact."""
+    if Artifact is None:
+        return None
+
+    result = await session.execute(
+        select(Artifact.blob_uri)
+        .where(Artifact.video_id == video_id, Artifact.artifact_type == artifact_type)
+        .limit(1)
+    )
+    blob_uri = result.scalar_one_or_none()
+    if not blob_uri:
+        return None
+
+    return extract_blob_name_from_uri(blob_uri, container_name)
 
 
 @router.post(
@@ -225,20 +254,39 @@ async def get_video_transcript(
             detail="Video not found",
         )
 
-    # Get channel name for blob path lookup
+    # Prefer the persisted artifact URI. It matches how completed videos are stored
+    # and avoids probing stale path formats that can be slow when missing.
     channel_name = video.channel.name if video.channel else "unknown-channel"
+    artifact_blob_name = await get_artifact_blob_name(
+        service.session,
+        video_id,
+        "transcript",
+        TRANSCRIPTS_CONTAINER,
+    )
+    fallback_blob_name = get_transcript_blob_path(channel_name, video.youtube_video_id)
+    blob_names = [name for name in [artifact_blob_name, fallback_blob_name] if name]
 
-    # Try to fetch transcript from blob storage using channel-based path
-    try:
-        blob_client = get_blob_client()
-        blob_name = get_transcript_blob_path(channel_name, video.youtube_video_id)
-        content = blob_client.download_blob(TRANSCRIPTS_CONTAINER, blob_name)
-        return PlainTextResponse(content.decode("utf-8"), media_type="text/plain")
-    except Exception as e:
+    blob_client = get_blob_client()
+    last_error: Exception | None = None
+    for index, blob_name in enumerate(dict.fromkeys(blob_names)):
+        try:
+            if index > 0 and not blob_client.blob_exists(TRANSCRIPTS_CONTAINER, blob_name):
+                continue
+            content = blob_client.download_blob(TRANSCRIPTS_CONTAINER, blob_name)
+            return PlainTextResponse(content.decode("utf-8"), media_type="text/plain")
+        except Exception as e:
+            last_error = e
+
+    if last_error is not None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Transcript not found: {str(e)}",
+            detail=f"Transcript not found: {str(last_error)}",
         )
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Transcript not found",
+    )
 
 
 @router.get(
@@ -263,20 +311,39 @@ async def get_video_summary(
             detail="Video not found",
         )
 
-    # Get channel name for blob path lookup
+    # Prefer the persisted artifact URI. It matches how completed videos are stored
+    # and avoids probing stale path formats that can be slow when missing.
     channel_name = video.channel.name if video.channel else "unknown-channel"
+    artifact_blob_name = await get_artifact_blob_name(
+        service.session,
+        video_id,
+        "summary",
+        SUMMARIES_CONTAINER,
+    )
+    fallback_blob_name = get_summary_blob_path(channel_name, video.youtube_video_id)
+    blob_names = [name for name in [artifact_blob_name, fallback_blob_name] if name]
 
-    # Try to fetch summary from blob storage using channel-based path
-    try:
-        blob_client = get_blob_client()
-        blob_name = get_summary_blob_path(channel_name, video.youtube_video_id)
-        content = blob_client.download_blob(SUMMARIES_CONTAINER, blob_name)
-        return PlainTextResponse(content.decode("utf-8"), media_type="text/markdown")
-    except Exception as e:
+    blob_client = get_blob_client()
+    last_error: Exception | None = None
+    for index, blob_name in enumerate(dict.fromkeys(blob_names)):
+        try:
+            if index > 0 and not blob_client.blob_exists(SUMMARIES_CONTAINER, blob_name):
+                continue
+            content = blob_client.download_blob(SUMMARIES_CONTAINER, blob_name)
+            return PlainTextResponse(content.decode("utf-8"), media_type="text/markdown")
+        except Exception as e:
+            last_error = e
+
+    if last_error is not None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Summary not found: {str(e)}",
+            detail=f"Summary not found: {str(last_error)}",
         )
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Summary not found",
+    )
 
 
 @router.post(

--- a/services/api/src/api/services/library_service.py
+++ b/services/api/src/api/services/library_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import contains_eager, noload, selectinload
 
 # Import shared modules
 try:
-    from shared.blob.client import SUMMARIES_CONTAINER, get_blob_client
+    from shared.blob.client import SUMMARIES_CONTAINER, extract_blob_name_from_uri, get_blob_client
     from shared.db.models import (
         Artifact,
         Channel,
@@ -36,6 +36,10 @@ except ImportError as e:
     VideoFacet = Any
     get_blob_client = None
     SUMMARIES_CONTAINER = "summaries"
+
+    def extract_blob_name_from_uri(blob_uri: str, container_name: str) -> str:
+        parts = blob_uri.split(f"/{container_name}/")
+        return parts[1] if len(parts) > 1 else blob_uri.split("/")[-1]
 
     def get_logger(name):
         import logging
@@ -160,25 +164,40 @@ class LibraryService:
         Returns:
             Paginated list of video cards.
         """
-        # Build base query
-        query = self._build_video_query(filters)
-
-        # Get total count
-        count_query = select(func.count()).select_from(query.subquery())
-        total_result = await self.session.execute(count_query)
-        total_count = total_result.scalar() or 0
+        segment_count_subquery = (
+            select(func.count())
+            .where(Segment.video_id == Video.video_id)
+            .correlate(Video)
+            .scalar_subquery()
+        )
 
         # Apply pagination
         offset = (filters.page - 1) * filters.page_size
-        query = query.offset(offset).limit(filters.page_size)
+        query = (
+            self._build_video_query(filters)
+            .add_columns(
+                segment_count_subquery.label("segment_count"),
+                func.count().over().label("total_count"),
+            )
+            .offset(offset)
+            .limit(filters.page_size)
+        )
 
         # Execute query
         result = await self.session.execute(query)
-        videos = result.scalars().all()
+        rows = list(result.all())
+        videos = [row[0] for row in rows]
+        total_count = rows[0].total_count if rows else 0
 
-        # Get segment counts for all videos
+        if not rows and filters.page > 1:
+            count_query = select(func.count()).select_from(
+                self._build_video_query(filters).subquery()
+            )
+            total_result = await self.session.execute(count_query)
+            total_count = total_result.scalar() or 0
+
         video_ids = [v.video_id for v in videos]
-        segment_counts = await self._get_segment_counts(video_ids)
+        segment_counts = {row[0].video_id: row.segment_count or 0 for row in rows}
 
         # Get facets for all videos
         video_facets = await self._get_video_facets(video_ids)
@@ -289,9 +308,9 @@ class LibraryService:
                 # blob_uri format: http://host/account/container/{video_id}/{youtube_video_id}_summary.md
                 # We need to extract: {video_id}/{youtube_video_id}_summary.md (everything after container name)
                 if artifact.blob_uri:
-                    parts = artifact.blob_uri.split(f"/{SUMMARIES_CONTAINER}/")
-                    summary_blob_name = (
-                        parts[1] if len(parts) > 1 else artifact.blob_uri.split("/")[-1]
+                    summary_blob_name = extract_blob_name_from_uri(
+                        artifact.blob_uri,
+                        SUMMARIES_CONTAINER,
                     )
                 else:
                     summary_blob_name = None
@@ -350,32 +369,34 @@ class LibraryService:
         Returns:
             Paginated list of segments or None if video not found.
         """
-        # Verify video exists
-        video_result = await self.session.execute(
-            select(Video.video_id, Video.youtube_video_id).where(Video.video_id == video_id)
-        )
-        video = video_result.one_or_none()
-        if not video:
-            return None
-
-        # Get total count
-        count_result = await self.session.execute(
-            select(func.count()).where(Segment.video_id == video_id)
-        )
-        total_count = count_result.scalar() or 0
-
-        # Get segments
         offset = (page - 1) * page_size
         segments_result = await self.session.execute(
-            select(Segment)
+            select(
+                Segment,
+                Video.youtube_video_id,
+                func.count().over().label("total_count"),
+            )
+            .join(Video, Segment.video_id == Video.video_id)
             .where(Segment.video_id == video_id)
             .order_by(Segment.sequence_number)
             .offset(offset)
             .limit(page_size)
         )
-        segments = segments_result.scalars().all()
+        rows = list(segments_result.all())
 
-        youtube_video_id = video.youtube_video_id
+        if rows:
+            segments = [row[0] for row in rows]
+            youtube_video_id = rows[0].youtube_video_id
+            total_count = rows[0].total_count or 0
+        else:
+            video_result = await self.session.execute(
+                select(Video.youtube_video_id).where(Video.video_id == video_id)
+            )
+            youtube_video_id = video_result.scalar_one_or_none()
+            if not youtube_video_id:
+                return None
+            segments = []
+            total_count = 0
 
         return SegmentListResponse(
             video_id=video_id,
@@ -411,38 +432,48 @@ class LibraryService:
         Returns:
             Paginated list of channel cards.
         """
-        query = select(Channel).options(noload(Channel.videos), noload(Channel.batches))
+        video_count_subquery = (
+            select(func.count())
+            .where(Video.channel_id == Channel.channel_id)
+            .correlate(Channel)
+            .scalar_subquery()
+        )
+
+        query = select(
+            Channel,
+            video_count_subquery.label("video_count"),
+            func.count().over().label("total_count"),
+        ).options(noload(Channel.videos), noload(Channel.batches))
 
         if search:
             query = query.where(Channel.name.ilike(f"%{search}%"))
-
-        # Get total count
-        count_query = select(func.count()).select_from(query.subquery())
-        total_result = await self.session.execute(count_query)
-        total_count = total_result.scalar() or 0
 
         # Apply pagination and ordering
         offset = (page - 1) * page_size
         query = query.order_by(Channel.name).offset(offset).limit(page_size)
 
         result = await self.session.execute(query)
-        channels = result.scalars().all()
+        rows = list(result.all())
+        total_count = rows[0].total_count if rows else 0
 
-        # Get video counts for each channel
-        channel_ids = [c.channel_id for c in channels]
-        video_counts = await self._get_channel_video_counts(channel_ids)
+        if not rows and page > 1:
+            count_query = select(func.count()).select_from(Channel)
+            if search:
+                count_query = count_query.where(Channel.name.ilike(f"%{search}%"))
+            total_result = await self.session.execute(count_query)
+            total_count = total_result.scalar() or 0
 
         return ChannelListResponse(
             channels=[
                 ChannelCard(
-                    channel_id=c.channel_id,
-                    youtube_channel_id=c.youtube_channel_id,
-                    name=c.name,
-                    thumbnail_url=c.thumbnail_url,
-                    video_count=video_counts.get(c.channel_id, 0),
-                    last_synced_at=c.last_synced_at,
+                    channel_id=row[0].channel_id,
+                    youtube_channel_id=row[0].youtube_channel_id,
+                    name=row[0].name,
+                    thumbnail_url=row[0].thumbnail_url,
+                    video_count=row.video_count or 0,
+                    last_synced_at=row[0].last_synced_at,
                 )
-                for c in channels
+                for row in rows
             ],
             page=page,
             page_size=page_size,
@@ -551,44 +582,44 @@ class LibraryService:
         Returns:
             Library statistics.
         """
-        # Total channels
-        channel_count = await self.session.execute(select(func.count()).select_from(Channel))
-        total_channels = channel_count.scalar() or 0
-
-        # Total videos
-        video_count = await self.session.execute(select(func.count()).select_from(Video))
-        total_videos = video_count.scalar() or 0
-
-        # Completed videos
-        completed_count = await self.session.execute(
-            select(func.count()).where(Video.processing_status == "completed")
+        result = await self.session.execute(
+            select(
+                select(func.count()).select_from(Channel).scalar_subquery().label("total_channels"),
+                select(func.count()).select_from(Video).scalar_subquery().label("total_videos"),
+                select(func.count())
+                .where(Video.processing_status == "completed")
+                .scalar_subquery()
+                .label("completed_videos"),
+                select(func.count()).select_from(Segment).scalar_subquery().label("total_segments"),
+                select(func.count())
+                .select_from(Relationship)
+                .scalar_subquery()
+                .label("total_relationships"),
+                select(func.count()).select_from(Facet).scalar_subquery().label("total_facets"),
+                select(func.max(Video.updated_at)).scalar_subquery().label("last_updated_at"),
+            )
         )
-        completed_videos = completed_count.scalar() or 0
+        row = result.one_or_none()
 
-        # Total segments
-        segment_count = await self.session.execute(select(func.count()).select_from(Segment))
-        total_segments = segment_count.scalar() or 0
-
-        # Total relationships
-        rel_count = await self.session.execute(select(func.count()).select_from(Relationship))
-        total_relationships = rel_count.scalar() or 0
-
-        # Total facets
-        facet_count = await self.session.execute(select(func.count()).select_from(Facet))
-        total_facets = facet_count.scalar() or 0
-
-        # Last updated
-        last_updated_result = await self.session.execute(select(func.max(Video.updated_at)))
-        last_updated_at = last_updated_result.scalar()
+        if row is None:
+            return LibraryStatsResponse(
+                total_channels=0,
+                total_videos=0,
+                completed_videos=0,
+                total_segments=0,
+                total_relationships=0,
+                total_facets=0,
+                last_updated_at=None,
+            )
 
         return LibraryStatsResponse(
-            total_channels=total_channels,
-            total_videos=total_videos,
-            completed_videos=completed_videos,
-            total_segments=total_segments,
-            total_relationships=total_relationships,
-            total_facets=total_facets,
-            last_updated_at=last_updated_at,
+            total_channels=row.total_channels or 0,
+            total_videos=row.total_videos or 0,
+            completed_videos=row.completed_videos or 0,
+            total_segments=row.total_segments or 0,
+            total_relationships=row.total_relationships or 0,
+            total_facets=row.total_facets or 0,
+            last_updated_at=row.last_updated_at,
         )
 
     async def _get_segment_counts(self, video_ids: list[UUID]) -> dict[UUID, int]:

--- a/services/shared/shared/blob/__init__.py
+++ b/services/shared/shared/blob/__init__.py
@@ -7,9 +7,11 @@ from .client import (
     compute_content_hash,
     create_async_blob_service_client,
     create_blob_service_client,
+    extract_blob_name_from_uri,
     get_blob_client,
     get_connection_string,
     get_segments_blob_path,
+    get_summary_blob_path,
     get_transcript_blob_path,
     sanitize_channel_name,
 )
@@ -21,9 +23,11 @@ __all__ = [
     "compute_content_hash",
     "create_async_blob_service_client",
     "create_blob_service_client",
+    "extract_blob_name_from_uri",
     "get_blob_client",
     "get_connection_string",
     "get_segments_blob_path",
+    "get_summary_blob_path",
     "get_transcript_blob_path",
     "sanitize_channel_name",
 ]

--- a/services/shared/shared/blob/client.py
+++ b/services/shared/shared/blob/client.py
@@ -10,7 +10,7 @@ from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 # Default container names
 TRANSCRIPTS_CONTAINER = "transcripts"
@@ -111,6 +111,16 @@ def get_summary_blob_path(channel_name: str, youtube_video_id: str) -> str:
     """
     sanitized = sanitize_channel_name(channel_name)
     return f"{sanitized}/{youtube_video_id}/summary.md"
+
+
+def extract_blob_name_from_uri(blob_uri: str, container_name: str) -> str:
+    """Extract a blob name from a stored blob URI.
+
+    Artifacts store the full blob URL, but Azure clients need the blob name within
+    the container. Preserve nested prefixes such as "{video_id}/summary.md".
+    """
+    parts = blob_uri.split(f"/{container_name}/")
+    return parts[1] if len(parts) > 1 else blob_uri.split("/")[-1]
 
 
 def convert_uri_to_connection_string(uri: str, service: str = "blob") -> str:
@@ -336,6 +346,7 @@ class BlobClient:
         return blob_client.url
 
     @retry(
+        retry=retry_if_not_exception_type(ResourceNotFoundError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
         reraise=True,

--- a/services/shared/tests/test_blob_helpers.py
+++ b/services/shared/tests/test_blob_helpers.py
@@ -1,6 +1,14 @@
 """Tests for blob storage helper functions."""
 
+from unittest.mock import MagicMock
+
+import pytest
+from azure.core.exceptions import ResourceNotFoundError
+
 from shared.blob.client import (
+    SUMMARIES_CONTAINER,
+    BlobClient,
+    extract_blob_name_from_uri,
     get_segments_blob_path,
     get_transcript_blob_path,
     sanitize_channel_name,
@@ -88,3 +96,43 @@ class TestGetSegmentsBlobPath:
         """Test that YouTube video ID is preserved exactly."""
         result = get_segments_blob_path("Channel", "ABC123xyz")
         assert result == "channel/ABC123xyz/segments.json"
+
+
+class TestExtractBlobNameFromUri:
+    """Tests for extracting blob names from stored artifact URIs."""
+
+    def test_preserves_nested_blob_prefix(self):
+        """Test that nested video ID prefixes are preserved."""
+        blob_uri = (
+            "https://account.blob.core.windows.net/summaries/"
+            "87af0899-c22d-4a54-9c01-bd2c3de59df7/video_summary.md"
+        )
+
+        result = extract_blob_name_from_uri(blob_uri, SUMMARIES_CONTAINER)
+
+        assert result == "87af0899-c22d-4a54-9c01-bd2c3de59df7/video_summary.md"
+
+    def test_falls_back_to_filename_for_simple_value(self):
+        """Test fallback behavior for legacy simple blob names."""
+        assert extract_blob_name_from_uri("video_summary.md", SUMMARIES_CONTAINER) == (
+            "video_summary.md"
+        )
+
+
+class TestBlobClientDownload:
+    """Tests for blob download retry behavior."""
+
+    def test_download_blob_does_not_retry_missing_blob(self):
+        """Missing blobs should fail quickly instead of retrying slow 404s."""
+        blob_client = MagicMock()
+        blob_client.download_blob.side_effect = ResourceNotFoundError("missing")
+        service_client = MagicMock()
+        service_client.get_blob_client.return_value = blob_client
+
+        client = BlobClient()
+        client._client = service_client
+
+        with pytest.raises(ResourceNotFoundError):
+            client.download_blob("summaries", "missing.md")
+
+        blob_client.download_blob.assert_called_once()


### PR DESCRIPTION
## Summary
- Fix transcript/summary content routes to prefer persisted artifact blob URIs before falling back to legacy channel paths.
- Stop retrying Azure Blob `ResourceNotFoundError` so missing blob responses fail quickly instead of waiting through retry backoff.
- Reduce avoidable Azure SQL round trips in library video, channel, segment, and stats endpoints.

## What caused the slow pages
- OpenClaw to Azure SQL has a warm per-query round trip of roughly 200 ms, so endpoints with 4-7 sequential SQL calls were taking 1-2 seconds even when each query was simple.
- The completed-video transcript tab was calling `/api/v1/videos/{id}/transcript`, which looked up the legacy channel-path blob and returned a slow 404 after Azure Blob retries. Browser timing showed about 5.4 seconds for that failed request.

## Production pod dry-run of new query shapes
- Library videos page query path: ~1.5s -> ~0.95s inside pod.
- Channel filter: ~1.0s -> ~0.4s.
- Library stats: ~1.7s -> ~0.4s.
- Segment list: ~1.25s -> ~0.4s.
- Transcript route changes from slow missing-blob 404 to artifact-backed fetch.

## Verification
- `uv run --project services/shared pytest services/shared/tests/test_blob_helpers.py -q` -> 19 passed
- `./scripts/run-tests.ps1 -Component shared` -> 42 passed
- `PYTHONPATH=services/shared;services/api/src uv run --project services/api pytest services/api/tests/test_library.py services/api/tests/test_library_service.py services/api/tests/test_videos.py -q` -> 84 passed
- `python -m pre_commit run --all-files --verbose` -> passed

## Local test caveat
- `./scripts/run-tests.ps1 -Component api` currently reports 509 passed / 6 failed, all in `tests/test_auth_integration.py`; those failures are auth/session shape and Auth0 redirect issues unrelated to these API/library/blob changes.
- `./scripts/run-tests.ps1 -Component all` timed out locally after 15 minutes. Local port 8000 is already occupied by an unrelated uvicorn process, which can confuse the E2E Aspire detection in the script.