### PR TITLE
Fix transcript-only batch processing mode

### DIFF
--- a/apps/web/e2e/processing-history.spec.ts
+++ b/apps/web/e2e/processing-history.spec.ts
@@ -33,9 +33,10 @@ test.describe('Processing History', () => {
   let secondVideoIdWithHistory: string | null = null;
 
   test.beforeAll(async ({ request }) => {
-    // Find up to 2 completed videos that actually have processing history records.
+    // Find up to 2 completed full-analysis videos that actually have processing history records.
     // Old videos may have been processed before history tracking was added,
-    // so we verify the /history endpoint returns stages before picking a video.
+    // and transcript-only videos intentionally do not have summary/embed stages,
+    // so we verify the /history endpoint returns AI stages before picking a video.
     const listResponse = await request.get(
       `${API_URL}/api/v1/library/videos?status=completed&page_size=50`
     );
@@ -48,7 +49,12 @@ test.describe('Processing History', () => {
       );
       if (!historyResponse.ok()) continue;
       const historyData = await historyResponse.json();
-      if (historyData.stages && historyData.stages.length > 0) {
+      const historyText = JSON.stringify(historyData).toLowerCase();
+      const hasFullAnalysisHistory =
+        historyData.stages &&
+        historyData.stages.length > 0 &&
+        (historyText.includes('summar') || historyText.includes('embed'));
+      if (hasFullAnalysisHistory) {
         if (!videoIdWithHistory) {
           videoIdWithHistory = video.video_id;
           console.log(`[processing-history] Found video 1 with history: ${videoIdWithHistory}`);
@@ -62,7 +68,7 @@ test.describe('Processing History', () => {
       }
     }
     if (!videoIdWithHistory) {
-      console.log('[processing-history] No completed videos with history records found');
+      console.log('[processing-history] No completed full-analysis videos with history found');
     }
   });
 

--- a/services/api/src/api/services/batch_service.py
+++ b/services/api/src/api/services/batch_service.py
@@ -61,7 +61,7 @@ from ..models.batch import (
     BatchItem as BatchItemResponse,
 )
 from ..models.job import JobStage, JobStatus, JobType
-from ..models.processing import ProcessingMode
+from ..models.processing import ProcessingMode, normalize_processing_mode
 from .channel_service import ChannelService
 from .youtube_service import get_youtube_service
 
@@ -106,7 +106,7 @@ class BatchService:
             ai_features_quota_slots: Number of AI feature jobs to reserve immediately.
                 None means unlimited.
         """
-        processing_mode = request.processing_mode
+        processing_mode = normalize_processing_mode(request.processing_mode)
         logger.info(
             "Creating batch",
             name=request.name,

--- a/services/api/tests/test_batches.py
+++ b/services/api/tests/test_batches.py
@@ -4,8 +4,8 @@ These tests verify the batch creation, listing, and management endpoints.
 Batch API is critical for User Story 2: Ingest from Channel.
 """
 
-from datetime import datetime
-from unittest.mock import MagicMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -164,6 +164,54 @@ class TestCreateBatch:
             status.HTTP_422_UNPROCESSABLE_ENTITY,  # Validation error
             status.HTTP_500_INTERNAL_SERVER_ERROR,
         ]
+
+
+class TestBatchServiceCreate:
+    """Focused service tests for batch creation behavior."""
+
+    @pytest.mark.asyncio
+    async def test_create_batch_normalizes_string_processing_mode(self, sample_youtube_video_ids):
+        """Regression: API requests may provide processing_mode as a raw string."""
+        from api.models.batch import CreateBatchRequest
+        from api.models.processing import ProcessingMode
+        from api.services.batch_service import BatchService
+
+        session = MagicMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        def assign_batch_defaults():
+            batch = session.add.call_args.args[0]
+            batch.batch_id = uuid4()
+            batch.status = "pending"
+            batch.created_at = datetime.now(UTC)
+            batch.updated_at = batch.created_at
+
+        session.flush.side_effect = assign_batch_defaults
+
+        request = CreateBatchRequest(
+            name="Transcript Only Batch",
+            video_ids=[sample_youtube_video_ids[0]],
+            processing_mode="transcript_only",
+        )
+        service = BatchService(session)
+        service._create_batch_item = AsyncMock(return_value=(True, False))
+
+        with patch("api.services.batch_service.record_usage", new=AsyncMock()):
+            response = await service.create_batch(
+                request,
+                correlation_id="test-correlation",
+                user_id=None,
+                transcript_quota_slots=1,
+                ai_features_quota_slots=None,
+            )
+
+        assert response.processing_mode == ProcessingMode.TRANSCRIPT_ONLY
+        service._create_batch_item.assert_awaited_once()
+        assert service._create_batch_item.await_args.kwargs["processing_mode"] == (
+            ProcessingMode.TRANSCRIPT_ONLY
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Normalize batch processing_mode at the service boundary so API requests that arrive as raw strings do not crash
- Add a focused regression test for transcript_only batch creation

## Verification
- Found during production canary: POST /api/v1/batches with processing_mode=transcript_only returned 500: AttributeError: 'str' object has no attribute 'value'
- ./scripts/run-tests.ps1 -Component all: 1309 passed, 0 failed
- ./scripts/run-tests.ps1 -Component api: 527 passed, 0 failed after rebase
- python -m pre_commit run --all-files --verbose: passed
