### PR TITLE
Fix batch proxy metadata logging

### DIFF
--- a/services/api/src/api/services/batch_service.py
+++ b/services/api/src/api/services/batch_service.py
@@ -408,7 +408,7 @@ class BatchService:
 
         ctx = (
             self._proxy_service.log_request(
-                url=f"https://www.youtube.com/watch?v={youtube_video_id}",
+                service="api",
                 operation="batch_fetch_video_metadata",
             )
             if self._proxy_service is not None

--- a/services/api/tests/test_batches.py
+++ b/services/api/tests/test_batches.py
@@ -213,6 +213,56 @@ class TestBatchServiceCreate:
             ProcessingMode.TRANSCRIPT_ONLY
         )
 
+    @pytest.mark.asyncio
+    async def test_fetch_video_metadata_uses_proxy_log_contract(self):
+        """Regression: proxy logging in batch metadata fetch must match ProxyService."""
+        from api.services.batch_service import BatchService
+
+        class AsyncContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeYoutubeDL:
+            def __init__(self, opts):
+                self.opts = opts
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def extract_info(self, url, download=False):
+                return {
+                    "title": "Test Video",
+                    "description": "Description",
+                    "duration": 123,
+                    "upload_date": "20260102",
+                    "thumbnails": [{"url": "https://example.com/thumb.jpg", "height": 720}],
+                    "channel_id": "UC_test",
+                    "channel": "Test Channel",
+                    "channel_thumbnail_url": "https://example.com/channel.jpg",
+                }
+
+        proxy_service = MagicMock()
+        proxy_service.get_ydl_opts.return_value = {"proxy": "http://proxy.example"}
+        proxy_service.log_request.return_value = AsyncContext()
+
+        service = BatchService(MagicMock())
+        service._proxy_service = proxy_service
+
+        with patch("yt_dlp.YoutubeDL", FakeYoutubeDL):
+            metadata = await service._fetch_video_metadata("abc123")
+
+        assert metadata["title"] == "Test Video"
+        proxy_service.log_request.assert_called_once_with(
+            service="api",
+            operation="batch_fetch_video_metadata",
+        )
+
 
 # ============================================================================
 # List Batches Tests


### PR DESCRIPTION
## Summary
- Fixes production batch metadata fetch when proxy logging is enabled.
- Aligns `BatchService._fetch_video_metadata` with the `ProxyService.log_request(service, operation)` contract.
- Adds a regression test covering the proxy-enabled batch metadata path.

## Why
Production canary batch creation no longer failed with the old processing-mode 500, but the batch stayed pending with no items. OpenClaw API logs showed:

`ProxyService.log_request() got an unexpected keyword argument 'url'`

That exception was swallowed per video and left the batch in a misleading pending state.

## Verification
- `cd services/api; uv run pytest tests/test_batches.py -q` -> 27 passed
- `./scripts/run-tests.ps1 -Component e2e` -> 219 passed, 17 skipped
- `./scripts/run-tests.ps1 -Component all` -> 1316 passed, 0 failed
- `python -m pre_commit run --all-files --verbose` -> passed