### PR TITLE
feat(openclaw): autoscale transcribe worker

### DIFF
--- a/k8s/overlays/openclaw-prod/kustomization.yaml
+++ b/k8s/overlays/openclaw-prod/kustomization.yaml
@@ -12,6 +12,7 @@ namespace: yt-summarizer
 
 resources:
   - ../prod
+  - transcribe-worker-scaledobject.yaml
 
 images:
   # The nested ../prod overlay rewrites short image names to ACR names first.
@@ -81,6 +82,27 @@ patches:
         value: api-ytsummarizer.ashleyhollis.com
       - op: remove
         path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: transcribe-worker
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transcribe-worker
+      spec:
+        template:
+          spec:
+            containers:
+              - name: worker
+                env:
+                  - name: QUEUE_BATCH_SIZE
+                    value: "2"
+                  - name: PROXY_MAX_CONCURRENCY
+                    value: "2"
 
 labels:
   - pairs:

--- a/k8s/overlays/openclaw-prod/transcribe-worker-scaledobject.yaml
+++ b/k8s/overlays/openclaw-prod/transcribe-worker-scaledobject.yaml
@@ -1,0 +1,22 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: transcribe-worker
+  namespace: yt-summarizer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  scaleTargetRef:
+    name: transcribe-worker
+  pollingInterval: 30
+  cooldownPeriod: 300
+  minReplicaCount: 1
+  maxReplicaCount: 5
+  triggers:
+    - type: azure-queue
+      metadata:
+        queueName: transcribe-jobs
+        queueLength: "4"
+        queueLengthStrategy: all
+        activationQueueLength: "1"
+        connectionFromEnv: AZURE_STORAGE_CONNECTION_STRING


### PR DESCRIPTION
## Summary
- Add a KEDA ScaledObject for the OpenClaw production transcribe worker
- Cap each transcribe pod to QUEUE_BATCH_SIZE=2 and PROXY_MAX_CONCURRENCY=2
- Scale from 1 to 5 replicas based on Azure Storage Queue depth including invisible messages

## Validation
- kubectl kustomize k8s/overlays/openclaw-prod
- ./scripts/run-tests.ps1 -Component all
- python -m pre_commit run --all-files --verbose