### PR TITLE
fix(openclaw): preserve transcribe autoscaling overlay

### DIFF
--- a/k8s/overlays/openclaw-prod/kustomization.yaml
+++ b/k8s/overlays/openclaw-prod/kustomization.yaml
@@ -12,6 +12,7 @@ namespace: yt-summarizer
 
 resources:
   - ../prod
+  - transcribe-worker-scaledobject.yaml
 
 images:
   # The nested ../prod overlay rewrites short image names to ACR names first.
@@ -81,6 +82,27 @@ patches:
         value: api-ytsummarizer.ashleyhollis.com
       - op: remove
         path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: transcribe-worker
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transcribe-worker
+      spec:
+        template:
+          spec:
+            containers:
+              - name: worker
+                env:
+                  - name: QUEUE_BATCH_SIZE
+                    value: "2"
+                  - name: PROXY_MAX_CONCURRENCY
+                    value: "2"
 
 labels:
   - pairs:

--- a/scripts/ci/templates/prod-openclaw-kustomization-template.yaml
+++ b/scripts/ci/templates/prod-openclaw-kustomization-template.yaml
@@ -8,6 +8,7 @@ namespace: yt-summarizer
 
 resources:
   - ../prod
+  - transcribe-worker-scaledobject.yaml
 
 images:
   # The nested ../prod overlay rewrites short image names to ACR names first.
@@ -77,6 +78,27 @@ patches:
         value: api-ytsummarizer.ashleyhollis.com
       - op: remove
         path: /metadata/annotations/external-dns.alpha.kubernetes.io~1hostname
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: transcribe-worker
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transcribe-worker
+      spec:
+        template:
+          spec:
+            containers:
+              - name: worker
+                env:
+                  - name: QUEUE_BATCH_SIZE
+                    value: "2"
+                  - name: PROXY_MAX_CONCURRENCY
+                    value: "2"
 
 labels:
   - pairs:


### PR DESCRIPTION
## Summary
- Update the OpenClaw production kustomization template so future image-tag deployments keep the transcribe ScaledObject reference
- Restore the current generated OpenClaw production overlay reference and worker env caps

## Validation
- kubectl kustomize k8s/overlays/openclaw-prod
- ./scripts/run-tests.ps1 -Component all
- python -m pre_commit run --all-files --verbose