### PR TITLE
Fix batch dispatch and transcribe retry handling

### DIFF
--- a/k8s/overlays/openclaw-prod/transcribe-worker-scaledobject.yaml
+++ b/k8s/overlays/openclaw-prod/transcribe-worker-scaledobject.yaml
@@ -11,7 +11,7 @@ spec:
   pollingInterval: 30
   cooldownPeriod: 300
   minReplicaCount: 1
-  maxReplicaCount: 5
+  maxReplicaCount: 8
   triggers:
     - type: azure-queue
       metadata:

--- a/services/api/src/api/routes/admin.py
+++ b/services/api/src/api/routes/admin.py
@@ -1,5 +1,7 @@
 """Admin routes for system management and recovery."""
 
+from __future__ import annotations
+
 import json
 from datetime import datetime
 from typing import Any

--- a/services/api/src/api/services/batch_service.py
+++ b/services/api/src/api/services/batch_service.py
@@ -1,6 +1,7 @@
 """Batch service for batch ingestion operations."""
 
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -162,6 +163,7 @@ class BatchService:
         # Process each video (quota-aware dispatching)
         transcript_released_count = 0
         ai_released_count = 0
+        queued_transcribe_messages: list[dict[str, Any]] = []
         for youtube_video_id in video_ids_to_ingest:
             # Determine quota status for this job
             if (
@@ -181,7 +183,11 @@ class BatchService:
                     ai_quota_status = "quota_queued"
 
             try:
-                transcript_released, ai_released = await self._create_batch_item(
+                (
+                    transcript_released,
+                    ai_released,
+                    transcribe_message,
+                ) = await self._create_batch_item(
                     batch=batch,
                     youtube_video_id=youtube_video_id,
                     correlation_id=correlation_id,
@@ -191,6 +197,8 @@ class BatchService:
                     ai_quota_status=ai_quota_status,
                     processing_mode=processing_mode,
                 )
+                if transcribe_message is not None:
+                    queued_transcribe_messages.append(transcribe_message)
                 if transcript_released:
                     transcript_released_count += 1
                     if user_id:
@@ -218,6 +226,8 @@ class BatchService:
                 # Continue with other videos
 
         await self.session.commit()
+
+        self._dispatch_transcribe_messages(queued_transcribe_messages)
 
         logger.info(
             "Created batch",
@@ -250,7 +260,7 @@ class BatchService:
         quota_status: str = "released",
         ai_quota_status: str = "released",
         processing_mode: ProcessingMode = ProcessingMode.FULL_ANALYSIS,
-    ) -> tuple[bool, bool]:
+    ) -> tuple[bool, bool, dict[str, Any] | None]:
         """Create a batch item for a single video.
 
         Args:
@@ -264,7 +274,10 @@ class BatchService:
             processing_mode: Requested processing depth.
 
         Returns:
-            Tuple of (released_transcript_job_created, released_ai_job_created).
+            Tuple of:
+            - whether a released transcribe job was created
+            - whether a released AI job was created
+            - transcribe queue message to publish after commit, when applicable
         """
         # Check if video already exists
         result = await self.session.execute(
@@ -285,7 +298,7 @@ class BatchService:
             if video.processing_status == "completed":
                 batch.pending_count -= 1
                 batch.succeeded_count += 1
-            return (False, False)
+            return (False, False, None)
 
         # Fetch video metadata
         video_metadata = await self._fetch_video_metadata(youtube_video_id)
@@ -350,32 +363,39 @@ class BatchService:
             self.session.add(ai_job)
             ai_job_released = ai_quota_status == "released"
 
-        # Only dispatch to queue if released (not quota_queued)
+        transcribe_message: dict[str, Any] | None = None
+        # Only dispatch to queue if released (not quota_queued), after DB commit.
         if quota_status == "released":
+            transcribe_message = {
+                "job_id": str(job.job_id),
+                "video_id": str(video.video_id),
+                "youtube_video_id": youtube_video_id,
+                "channel_name": channel.name,
+                "batch_id": str(batch.batch_id),
+                "correlation_id": correlation_id,
+                "processing_mode": processing_mode.value,
+            }
+
+        return (quota_status == "released", ai_job_released, transcribe_message)
+
+    def _dispatch_transcribe_messages(self, messages: list[dict[str, Any]]) -> None:
+        """Publish transcribe jobs only after their database rows are committed."""
+        if not messages:
+            return
+
+        queue_client = get_queue_client()
+        for message in messages:
             try:
-                queue_client = get_queue_client()
                 queue_client.send_message(
                     TRANSCRIBE_QUEUE,
-                    inject_trace_context(
-                        {
-                            "job_id": str(job.job_id),
-                            "video_id": str(video.video_id),
-                            "youtube_video_id": youtube_video_id,
-                            "channel_name": channel.name,
-                            "batch_id": str(batch.batch_id),
-                            "correlation_id": correlation_id,
-                            "processing_mode": processing_mode.value,
-                        }
-                    ),
+                    inject_trace_context(message),
                 )
             except Exception as e:
                 logger.warning(
                     "Failed to queue job",
-                    job_id=str(job.job_id),
+                    job_id=message.get("job_id"),
                     error=str(e),
                 )
-
-        return (quota_status == "released", ai_job_released)
 
     async def _fetch_video_metadata(self, youtube_video_id: str) -> dict:
         """Fetch video metadata from YouTube using yt-dlp.

--- a/services/api/tests/test_batches.py
+++ b/services/api/tests/test_batches.py
@@ -196,7 +196,7 @@ class TestBatchServiceCreate:
             processing_mode="transcript_only",
         )
         service = BatchService(session)
-        service._create_batch_item = AsyncMock(return_value=(True, False))
+        service._create_batch_item = AsyncMock(return_value=(True, False, None))
 
         with patch("api.services.batch_service.record_usage", new=AsyncMock()):
             response = await service.create_batch(
@@ -212,6 +212,56 @@ class TestBatchServiceCreate:
         assert service._create_batch_item.await_args.kwargs["processing_mode"] == (
             ProcessingMode.TRANSCRIPT_ONLY
         )
+
+    @pytest.mark.asyncio
+    async def test_create_batch_dispatches_transcribe_messages_after_commit(
+        self, sample_youtube_video_ids
+    ):
+        """Regression: workers must not see queued jobs before SQL commit."""
+        from api.models.batch import CreateBatchRequest
+        from api.services.batch_service import BatchService
+
+        events = []
+        session = MagicMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+
+        async def commit():
+            events.append("commit")
+
+        def dispatch(messages):
+            events.append("dispatch")
+            assert messages == [{"job_id": "job-1"}]
+
+        def assign_batch_defaults():
+            batch = session.add.call_args.args[0]
+            batch.batch_id = uuid4()
+            batch.status = "pending"
+            batch.created_at = datetime.now(UTC)
+            batch.updated_at = batch.created_at
+
+        session.flush.side_effect = assign_batch_defaults
+        session.commit = AsyncMock(side_effect=commit)
+
+        request = CreateBatchRequest(
+            name="Transcript Only Batch",
+            video_ids=[sample_youtube_video_ids[0]],
+            processing_mode="transcript_only",
+        )
+        service = BatchService(session)
+        service._create_batch_item = AsyncMock(return_value=(True, False, {"job_id": "job-1"}))
+        service._dispatch_transcribe_messages = MagicMock(side_effect=dispatch)
+
+        with patch("api.services.batch_service.record_usage", new=AsyncMock()):
+            await service.create_batch(
+                request,
+                correlation_id="test-correlation",
+                user_id=None,
+                transcript_quota_slots=1,
+                ai_features_quota_slots=None,
+            )
+
+        assert events == ["commit", "dispatch"]
 
     @pytest.mark.asyncio
     async def test_fetch_video_metadata_uses_proxy_log_contract(self):

--- a/services/workers/tests/test_transcribe_resilience.py
+++ b/services/workers/tests/test_transcribe_resilience.py
@@ -199,6 +199,32 @@ class TestFetchTranscriptRetry:
             with pytest.raises(RateLimitError):
                 await worker._fetch_transcript_with_timestamps_and_text("test_video_id")
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "ERROR: [youtube] abc123: Sign in to confirm you're not a bot.",
+            "ERROR: [youtube] abc123: Sign in to confirm your age.",
+            "ERROR: [youtube] abc123: Use --cookies-from-browser or --cookies.",
+            "Tunnel connection failed: 402 Payment Required",
+        ],
+    )
+    async def test_auth_and_proxy_failures_stay_retryable(self, worker, error_message):
+        """Bot checks, auth prompts, and proxy billing failures are not no-caption results."""
+        import yt_dlp
+
+        from transcribe.worker import RateLimitError
+
+        with patch("yt_dlp.YoutubeDL") as mock_ydl_class:
+            mock_ydl = MagicMock()
+            mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+            mock_ydl.__exit__ = MagicMock(return_value=False)
+            mock_ydl.extract_info.side_effect = yt_dlp.utils.DownloadError(error_message)
+            mock_ydl_class.return_value = mock_ydl
+
+            with pytest.raises(RateLimitError):
+                await worker._fetch_transcript_with_timestamps_and_text("test_video_id")
+
 
 class TestWorkerResultOnInvalidContent:
     """Tests for worker behavior when content is invalid."""

--- a/services/workers/transcribe/worker.py
+++ b/services/workers/transcribe/worker.py
@@ -32,6 +32,19 @@ logger = get_logger(__name__)
 
 # Maximum length for content to be considered an error page when combined with other signals
 MAX_ERROR_PAGE_LENGTH = 1000
+RETRYABLE_YOUTUBE_ERROR_PHRASES = (
+    "429",
+    "too many",
+    "rate",
+    "block",
+    "ip",
+    "sign in to confirm",
+    "not a bot",
+    "cookies",
+    "age",
+    "payment required",
+    "unable to connect to proxy",
+)
 
 
 class RateLimitError(Exception):
@@ -630,9 +643,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 raise  # Re-raise rate limit errors
             except yt_dlp.utils.DownloadError as e:
                 error_str = str(e)
-                if any(
-                    phrase in error_str.lower() for phrase in ["429", "too many", "rate", "block"]
-                ):
+                if any(phrase in error_str.lower() for phrase in RETRYABLE_YOUTUBE_ERROR_PHRASES):
                     raise RateLimitError(
                         "YouTube is blocking requests from this IP. This may take hours to resolve."
                     )
@@ -640,10 +651,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 return None, None
             except Exception as e:
                 error_str = str(e)
-                if any(
-                    phrase in error_str.lower()
-                    for phrase in ["429", "too many", "rate", "block", "ip"]
-                ):
+                if any(phrase in error_str.lower() for phrase in RETRYABLE_YOUTUBE_ERROR_PHRASES):
                     raise RateLimitError(
                         "YouTube is blocking requests from this IP. This may take hours to resolve."
                     )


### PR DESCRIPTION
## Summary
- Dispatch batch transcribe queue messages only after the batch/job rows are committed.
- Keep YouTube bot-check, auth/cookie prompts, age gates, and proxy payment failures retryable instead of recording them as no-caption failures.
- Raise OpenClaw prod transcribe-worker KEDA max replicas from 5 to 8.
- Add postponed annotations in admin routes so backup tests can import under fallback test conditions.

## Verification
- `./scripts/run-tests.ps1` -> 793 passed, 0 failed, including E2E.
- `python -m pre_commit run --all-files --verbose` -> passed.
- Focused API/worker regression tests passed before the full gate.