### PR TITLE
Add age-gated transcript worker capability

### DIFF
--- a/docs/runbooks/video-ingestion-troubleshooting.md
+++ b/docs/runbooks/video-ingestion-troubleshooting.md
@@ -68,7 +68,49 @@ Get-Content aspire.log | Select-String -Pattern "job\.(started|completed|failed)
 
 ---
 
-### 3. OpenAI API Errors
+### 3. Age-Gated Videos
+
+**Symptoms**:
+- Error contains: "Age-gated video requires an age-gated transcript worker"
+- YouTube asks to sign in to confirm age
+- The video may have captions, but anonymous yt-dlp access cannot read metadata/subtitles
+
+**Behavior**:
+- Regular transcribe workers do not use browser cookies, even if cookie settings are present.
+- Age-gated failures are marked failed and terminal in the queue so regular workers do not keep
+  retrying the same message.
+- A transcribe worker must declare `TRANSCRIBE_CAPABILITIES=age_gated` before yt-dlp cookie
+  settings are honored.
+
+**Local recovery with an existing signed-in browser profile**:
+1. Make sure the target video is in a failed state with an age-gated error.
+2. Start only one local transcribe worker with an explicit capability and cookie source:
+   ```powershell
+   cd services/workers
+   $env:TRANSCRIBE_CAPABILITIES = "age_gated,local"
+   $env:YTDLP_COOKIES_FROM_BROWSER = "edge:Default"
+   uv run python -m transcribe
+   ```
+3. Retry the specific failed transcribe job or batch item.
+4. Stop the local worker after the recovery job succeeds.
+5. Clear the cookie-related environment variables from the shell.
+
+If the browser cookie database is locked, close the browser or export a temporary Netscape cookie
+file and use `YTDLP_COOKIES_FILE` instead. Treat exported cookie files as secrets and delete them
+after recovery.
+
+**Production account path**:
+- Do not store a personal YouTube browser profile or personal cookies in production.
+- For persistent PROD age-gated processing, create a dedicated YouTube account, document its owner
+  and recovery path, export or refresh an authenticated cookie/session artifact, store that artifact
+  in Azure Key Vault via Terraform, and deploy a dedicated age-gated transcribe worker that has
+  `TRANSCRIBE_CAPABILITIES=age_gated`.
+- Keep the regular transcribe worker pool unauthenticated so only the dedicated worker has the
+  expanded blast radius.
+
+---
+
+### 4. OpenAI API Errors
 
 **Symptoms**:
 - Summarize or embed jobs failing
@@ -91,7 +133,7 @@ Get-Content aspire.log | Select-String -Pattern "job\.(started|completed|failed)
 
 ---
 
-### 4. Database Write Failures
+### 5. Database Write Failures
 
 **Symptoms**:
 - Jobs fail at persist step
@@ -112,7 +154,7 @@ Get-Content aspire.log | Select-String -Pattern "job\.(started|completed|failed)
 
 ---
 
-### 5. Queue Message Failures
+### 6. Queue Message Failures
 
 **Symptoms**:
 - Job stuck between stages

--- a/services/shared/shared/config.py
+++ b/services/shared/shared/config.py
@@ -318,6 +318,55 @@ class QueueSettings(BaseSettings):
     )
 
 
+class TranscribeSettings(BaseSettings):
+    """Transcript worker capability and authenticated fetch settings.
+
+    Authenticated YouTube access is intentionally opt-in. Cookie settings are ignored unless the
+    worker declares the matching capability via TRANSCRIBE_CAPABILITIES=age_gated.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="TRANSCRIBE_")
+
+    capabilities: str = Field(
+        default="",
+        description="Comma-separated worker capabilities, for example: age_gated",
+    )
+
+    @property
+    def normalized_capabilities(self) -> set[str]:
+        """Return lower-case worker capabilities."""
+        return {
+            capability.strip().lower()
+            for capability in self.capabilities.split(",")
+            if capability.strip()
+        }
+
+    @property
+    def can_process_age_gated(self) -> bool:
+        """Whether this worker is allowed to use authenticated YouTube access."""
+        return "age_gated" in self.normalized_capabilities
+
+
+class YtDlpSettings(BaseSettings):
+    """yt-dlp authentication settings for local or dedicated age-gated workers."""
+
+    model_config = SettingsConfigDict(env_prefix="YTDLP_")
+
+    cookies_file: str = Field(
+        default="",
+        description="Path to a Netscape-format cookie file for yt-dlp.",
+    )
+    cookies_from_browser: str = Field(
+        default="",
+        description="Browser spec passed to yt-dlp cookiesfrombrowser, e.g. chrome or edge:Default.",
+    )
+
+    @property
+    def has_authentication(self) -> bool:
+        """Whether any yt-dlp authentication source is configured."""
+        return bool(self.cookies_file or self.cookies_from_browser)
+
+
 class LoggingSettings(BaseSettings):
     """Logging configuration settings."""
 
@@ -474,6 +523,8 @@ class Settings(BaseSettings):
     storage: AzureStorageSettings = Field(default_factory=AzureStorageSettings)
     openai: OpenAISettings = Field(default_factory=OpenAISettings)
     queue: QueueSettings = Field(default_factory=QueueSettings)
+    transcribe: TranscribeSettings = Field(default_factory=TranscribeSettings)
+    yt_dlp: YtDlpSettings = Field(default_factory=YtDlpSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
     api: APISettings = Field(default_factory=APISettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)

--- a/services/workers/.env.example
+++ b/services/workers/.env.example
@@ -30,3 +30,11 @@ PROXY_USERNAME=
 PROXY_PASSWORD=
 PROXY_MAX_CONCURRENCY=5
 PROXY_HEALTH_CHECK_TIMEOUT_SECONDS=10.0
+
+# Optional age-gated transcript recovery.
+# Cookie-backed YouTube access is ignored unless the worker explicitly declares
+# the age_gated capability. Use this locally with a temporary cookie source, or
+# in production only after provisioning a dedicated YouTube account/session.
+TRANSCRIBE_CAPABILITIES=
+YTDLP_COOKIES_FILE=
+YTDLP_COOKIES_FROM_BROWSER=

--- a/services/workers/tests/test_message_contracts.py
+++ b/services/workers/tests/test_message_contracts.py
@@ -301,6 +301,29 @@ class TestWorkerMessageOptionalFields:
             )
             assert transcript_only_message.processing_mode == "transcript_only"
 
+    def test_transcribe_worker_parses_required_capabilities(self, minimal_api_message):
+        """TranscribeWorker preserves optional capability routing hints."""
+        from transcribe.worker import TranscribeWorker
+
+        worker = TranscribeWorker()
+        message = worker.parse_message(
+            {
+                **minimal_api_message,
+                "required_capabilities": ["age_gated"],
+            }
+        )
+
+        assert message.required_capabilities == ["age_gated"]
+
+        message = worker.parse_message(
+            {
+                **minimal_api_message,
+                "required_capabilities": "age_gated, local",
+            }
+        )
+
+        assert message.required_capabilities == ["age_gated", "local"]
+
 
 # ============================================================================
 # Message Schema Tests - Missing Required Fields

--- a/services/workers/tests/test_transcribe_resilience.py
+++ b/services/workers/tests/test_transcribe_resilience.py
@@ -11,6 +11,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def refresh_settings_cache():
+    """Keep environment-driven worker settings isolated between tests."""
+    from shared.config import refresh_settings
+
+    refresh_settings()
+    yield
+    refresh_settings()
+
+
 class TestContentValidation:
     """Tests for _is_valid_transcript_content method."""
 
@@ -204,7 +214,6 @@ class TestFetchTranscriptRetry:
         "error_message",
         [
             "ERROR: [youtube] abc123: Sign in to confirm you're not a bot.",
-            "ERROR: [youtube] abc123: Sign in to confirm your age.",
             "ERROR: [youtube] abc123: Use --cookies-from-browser or --cookies.",
             "Tunnel connection failed: 402 Payment Required",
         ],
@@ -224,6 +233,140 @@ class TestFetchTranscriptRetry:
 
             with pytest.raises(RateLimitError):
                 await worker._fetch_transcript_with_timestamps_and_text("test_video_id")
+
+    @pytest.mark.asyncio
+    async def test_age_confirmation_is_classified_as_age_gated(self, worker):
+        """Age confirmation is a capability/auth problem, not a no-caption result."""
+        import yt_dlp
+
+        from transcribe.worker import AgeGatedTranscriptError
+
+        with patch("yt_dlp.YoutubeDL") as mock_ydl_class:
+            mock_ydl = MagicMock()
+            mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+            mock_ydl.__exit__ = MagicMock(return_value=False)
+            mock_ydl.extract_info.side_effect = yt_dlp.utils.DownloadError(
+                "ERROR: [youtube] abc123: Sign in to confirm your age."
+            )
+            mock_ydl_class.return_value = mock_ydl
+
+            with pytest.raises(AgeGatedTranscriptError):
+                await worker._fetch_transcript_with_timestamps_and_text("test_video_id")
+
+
+class TestAgeGatedWorkerCapability:
+    """Tests for explicit age-gated worker capability and yt-dlp auth options."""
+
+    def test_cookie_file_ignored_without_age_gated_capability(self, monkeypatch):
+        from shared.config import refresh_settings
+
+        from transcribe.worker import TranscribeWorker
+
+        monkeypatch.setenv("YTDLP_COOKIES_FILE", "C:/secure/youtube-cookies.txt")
+        refresh_settings()
+
+        worker = TranscribeWorker()
+
+        assert worker.can_process_age_gated is False
+        assert worker._get_yt_dlp_auth_opts() == {}
+
+    def test_cookie_file_used_with_age_gated_capability(self, monkeypatch):
+        from shared.config import refresh_settings
+
+        from transcribe.worker import TranscribeWorker
+
+        monkeypatch.setenv("TRANSCRIBE_CAPABILITIES", "age_gated")
+        monkeypatch.setenv("YTDLP_COOKIES_FILE", "C:/secure/youtube-cookies.txt")
+        refresh_settings()
+
+        worker = TranscribeWorker()
+
+        assert worker.can_process_age_gated is True
+        assert worker._get_yt_dlp_auth_opts() == {"cookiefile": "C:/secure/youtube-cookies.txt"}
+
+    def test_browser_profile_used_with_age_gated_capability(self, monkeypatch):
+        from shared.config import refresh_settings
+
+        from transcribe.worker import TranscribeWorker
+
+        monkeypatch.setenv("TRANSCRIBE_CAPABILITIES", "age_gated,local")
+        monkeypatch.setenv("YTDLP_COOKIES_FROM_BROWSER", "edge:Default")
+        refresh_settings()
+
+        worker = TranscribeWorker()
+
+        assert worker.can_process_age_gated is True
+        assert worker.capabilities == {"age_gated", "local"}
+        assert worker._get_yt_dlp_auth_opts() == {
+            "cookiesfrombrowser": ("edge", "Default", None, None)
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_required_capability_fails_before_youtube_call(self):
+        from shared.worker.base_worker import WorkerStatus
+
+        from transcribe.worker import TranscribeMessage, TranscribeWorker
+
+        worker = TranscribeWorker()
+        message = TranscribeMessage(
+            job_id="test-job-id",
+            video_id="test-video-id",
+            youtube_video_id="age_gated_video",
+            correlation_id="test-correlation",
+            required_capabilities=["age_gated"],
+        )
+
+        with (
+            patch("transcribe.worker.mark_job_running", new_callable=AsyncMock),
+            patch("transcribe.worker.mark_job_failed", new_callable=AsyncMock) as mock_failed,
+            patch.object(
+                worker, "_fetch_transcript_with_timestamps_and_text", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            result = await worker.process_message(message, "test-correlation")
+
+            assert result.status == WorkerStatus.DEAD_LETTER
+            assert "age_gated" in result.message
+            mock_failed.assert_called_once()
+            mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_age_gated_error_marks_job_failed_with_clear_message(self):
+        from shared.worker.base_worker import WorkerStatus
+
+        from transcribe.worker import (
+            AGE_GATED_TRANSCRIPT_ERROR,
+            AgeGatedTranscriptError,
+            TranscribeMessage,
+            TranscribeWorker,
+        )
+
+        worker = TranscribeWorker()
+        message = TranscribeMessage(
+            job_id="test-job-id",
+            video_id="test-video-id",
+            youtube_video_id="age_gated_video",
+            correlation_id="test-correlation",
+        )
+
+        with (
+            patch("transcribe.worker.mark_job_running", new_callable=AsyncMock),
+            patch("transcribe.worker.mark_job_failed", new_callable=AsyncMock) as mock_failed,
+            patch.object(
+                worker, "_check_existing_transcript", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(worker, "_has_permanent_no_captions", return_value=False),
+            patch.object(
+                worker, "_fetch_transcript_with_timestamps_and_text", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.side_effect = AgeGatedTranscriptError(AGE_GATED_TRANSCRIPT_ERROR)
+
+            result = await worker.process_message(message, "test-correlation")
+
+            assert result.status == WorkerStatus.DEAD_LETTER
+            assert result.message == AGE_GATED_TRANSCRIPT_ERROR
+            mock_failed.assert_called_once_with(message.job_id, AGE_GATED_TRANSCRIPT_ERROR)
 
 
 class TestWorkerResultOnInvalidContent:

--- a/services/workers/transcribe/worker.py
+++ b/services/workers/transcribe/worker.py
@@ -41,14 +41,27 @@ RETRYABLE_YOUTUBE_ERROR_PHRASES = (
     "sign in to confirm",
     "not a bot",
     "cookies",
-    "age",
     "payment required",
     "unable to connect to proxy",
+)
+AGE_GATED_YOUTUBE_ERROR_PHRASES = (
+    "sign in to confirm your age",
+    "age-restricted",
+    "inappropriate for some users",
+)
+AGE_GATED_TRANSCRIPT_ERROR = (
+    "Age-gated video requires an age-gated transcript worker with authenticated YouTube cookies."
 )
 
 
 class RateLimitError(Exception):
     """Raised when YouTube rate limits or IP blocks our requests."""
+
+    pass
+
+
+class AgeGatedTranscriptError(Exception):
+    """Raised when YouTube requires authenticated age confirmation."""
 
     pass
 
@@ -65,6 +78,7 @@ class TranscribeMessage:
     batch_id: str | None = None
     processing_mode: str = "full_analysis"
     retry_count: int = 0
+    required_capabilities: list[str] | None = None
 
 
 class TranscribeWorker(BaseWorker[TranscribeMessage]):
@@ -82,6 +96,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
     def __init__(self):
         """Initialize with proxy-aware rate limiting."""
         settings = get_settings()
+        self._settings = settings
         self._proxy_service = ProxyService(settings.proxy)
 
         # When proxy is active the gateway provides IP rotation — no need for
@@ -98,6 +113,12 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
         self._last_youtube_request_time: float | None = None
         self._youtube_request_count: int = 0
         self._youtube_timing_lock = asyncio.Lock()
+
+        if settings.yt_dlp.has_authentication and not self.can_process_age_gated:
+            logger.warning(
+                "yt-dlp authentication is configured but age_gated capability is missing; "
+                "cookie settings will be ignored",
+            )
 
     @property
     def queue_name(self) -> str:
@@ -163,7 +184,76 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
             batch_id=raw_message.get("batch_id"),
             processing_mode=raw_message.get("processing_mode", "full_analysis"),
             retry_count=raw_message.get("retry_count", 0),
+            required_capabilities=self._normalize_capabilities(
+                raw_message.get("required_capabilities")
+            ),
         )
+
+    @property
+    def capabilities(self) -> set[str]:
+        """Return capabilities declared by this worker instance."""
+        return self._settings.transcribe.normalized_capabilities
+
+    @property
+    def can_process_age_gated(self) -> bool:
+        """Whether this worker is explicitly allowed to use authenticated YouTube cookies."""
+        return self._settings.transcribe.can_process_age_gated
+
+    def _normalize_capabilities(self, capabilities: Any) -> list[str] | None:
+        """Normalize queue capability hints from list or comma-separated payloads."""
+        if capabilities is None:
+            return None
+        if isinstance(capabilities, str):
+            items = capabilities.split(",")
+        else:
+            items = capabilities
+        normalized = [
+            str(capability).strip().lower() for capability in items if str(capability).strip()
+        ]
+        return normalized or None
+
+    def _missing_required_capabilities(self, message: TranscribeMessage) -> list[str]:
+        """Return message capabilities that this worker does not provide."""
+        required = {
+            capability.strip().lower()
+            for capability in (message.required_capabilities or [])
+            if capability.strip()
+        }
+        return sorted(required - self.capabilities)
+
+    def _get_yt_dlp_auth_opts(self) -> dict[str, Any]:
+        """Return authenticated yt-dlp options for age-gated workers only."""
+        if not self.can_process_age_gated:
+            return {}
+
+        yt_dlp_settings = self._settings.yt_dlp
+        if yt_dlp_settings.cookies_file:
+            return {"cookiefile": yt_dlp_settings.cookies_file}
+        if yt_dlp_settings.cookies_from_browser:
+            return {
+                "cookiesfrombrowser": self._parse_cookies_from_browser(
+                    yt_dlp_settings.cookies_from_browser
+                )
+            }
+        return {}
+
+    def _parse_cookies_from_browser(
+        self, cookies_from_browser: str
+    ) -> tuple[str, str | None, str | None, str | None]:
+        """Parse yt-dlp's BROWSER[+KEYRING][:PROFILE][::CONTAINER] browser cookie spec."""
+        import re
+
+        match = re.fullmatch(
+            r"(?P<name>[^+:]+)(?:\s*\+\s*(?P<keyring>[^:]+))?"
+            r"(?:\s*:\s*(?!:)(?P<profile>.+?))?(?:\s*::\s*(?P<container>.+))?",
+            cookies_from_browser,
+        )
+        if not match:
+            raise ValueError(f"Invalid YTDLP_COOKIES_FROM_BROWSER value: {cookies_from_browser}")
+        browser_name, keyring, profile, container = match.group(
+            "name", "keyring", "profile", "container"
+        )
+        return browser_name.lower(), profile, keyring.upper() if keyring else None, container
 
     async def _has_permanent_no_captions(self, video_id: str) -> bool:
         """Check if a prior job already determined this video has no captions.
@@ -221,6 +311,15 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
         try:
             # Mark job as running
             await mark_job_running(message.job_id, "transcribing")
+
+            missing_capabilities = self._missing_required_capabilities(message)
+            if missing_capabilities:
+                error_msg = (
+                    "Transcribe job requires worker capabilities that this worker does not have: "
+                    f"{', '.join(missing_capabilities)}."
+                )
+                await mark_job_failed(message.job_id, error_msg)
+                return WorkerResult.dead_letter(error_msg)
 
             # Short-circuit: if a prior job already determined this video has no captions,
             # fail immediately instead of hitting YouTube (which may rate-limit us again).
@@ -289,6 +388,17 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 message="YouTube is rate limiting requests. Will retry automatically in 5 minutes.",
                 retry_delay=retry_delay,
             )
+        except AgeGatedTranscriptError:
+            logger.warning(
+                "Age-gated video requires authenticated transcript worker",
+                job_id=message.job_id,
+                video_id=message.video_id,
+                youtube_video_id=message.youtube_video_id,
+                age_gated_capability=self.can_process_age_gated,
+                ytdlp_auth_configured=self._settings.yt_dlp.has_authentication,
+            )
+            await mark_job_failed(message.job_id, AGE_GATED_TRANSCRIPT_ERROR)
+            return WorkerResult.dead_letter(AGE_GATED_TRANSCRIPT_ERROR)
 
         try:
             # Store transcript in blob storage (using channel-based path)
@@ -546,6 +656,8 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 },
                 # Proxy routing — empty dict when proxy is disabled (T013)
                 **self._proxy_service.get_ydl_opts(),
+                # Authenticated YouTube access is only enabled on explicit age-gated workers.
+                **self._get_yt_dlp_auth_opts(),
             }
 
             logger.info(
@@ -553,6 +665,8 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 video_id=youtube_video_id,
                 sleep_seconds=subtitle_sleep,
                 proxy_enabled=self._proxy_service.enabled,
+                age_gated_capability=self.can_process_age_gated,
+                ytdlp_auth_configured=self._settings.yt_dlp.has_authentication,
             )
 
             try:
@@ -643,6 +757,8 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 raise  # Re-raise rate limit errors
             except yt_dlp.utils.DownloadError as e:
                 error_str = str(e)
+                if any(phrase in error_str.lower() for phrase in AGE_GATED_YOUTUBE_ERROR_PHRASES):
+                    raise AgeGatedTranscriptError(AGE_GATED_TRANSCRIPT_ERROR)
                 if any(phrase in error_str.lower() for phrase in RETRYABLE_YOUTUBE_ERROR_PHRASES):
                     raise RateLimitError(
                         "YouTube is blocking requests from this IP. This may take hours to resolve."
@@ -651,6 +767,8 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 return None, None
             except Exception as e:
                 error_str = str(e)
+                if any(phrase in error_str.lower() for phrase in AGE_GATED_YOUTUBE_ERROR_PHRASES):
+                    raise AgeGatedTranscriptError(AGE_GATED_TRANSCRIPT_ERROR)
                 if any(phrase in error_str.lower() for phrase in RETRYABLE_YOUTUBE_ERROR_PHRASES):
                     raise RateLimitError(
                         "YouTube is blocking requests from this IP. This may take hours to resolve."


### PR DESCRIPTION
## Summary
- add opt-in transcribe worker capabilities for age-gated YouTube transcript recovery
- gate yt-dlp cookie/browser auth behind TRANSCRIBE_CAPABILITIES=age_gated
- classify age confirmation as a terminal age-gated failure instead of retrying regular workers
- document local recovery and future dedicated PROD account/session handling

## Verification
- ./scripts/run-tests.ps1 (799 passed, 17 skipped)
- python -m pre_commit run --all-files --verbose
- ./scripts/run-tests.ps1 -Component workers (106 passed)