### PR TITLE
Fix age-gated subtitle-only transcript recovery

### DIFF
--- a/services/workers/tests/test_transcribe_resilience.py
+++ b/services/workers/tests/test_transcribe_resilience.py
@@ -302,6 +302,36 @@ class TestAgeGatedWorkerCapability:
         }
 
     @pytest.mark.asyncio
+    async def test_age_gated_cookie_download_uses_subtitle_only_options(self, monkeypatch):
+        from shared.config import refresh_settings
+
+        from transcribe.worker import TranscribeWorker
+
+        monkeypatch.setenv("TRANSCRIBE_CAPABILITIES", "age_gated")
+        monkeypatch.setenv("YTDLP_COOKIES_FILE", "C:/secure/youtube-cookies.txt")
+        refresh_settings()
+
+        worker = TranscribeWorker()
+
+        with patch("yt_dlp.YoutubeDL") as mock_ydl_class:
+            mock_ydl = MagicMock()
+            mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+            mock_ydl.__exit__ = MagicMock(return_value=False)
+            mock_ydl.extract_info.return_value = {"subtitles": {}, "automatic_captions": {}}
+            mock_ydl_class.return_value = mock_ydl
+
+            transcript, segments = await worker._fetch_transcript_with_timestamps_and_text(
+                "age_gated_video"
+            )
+
+            assert transcript is None
+            assert segments is None
+            ydl_opts = mock_ydl_class.call_args.args[0]
+            assert ydl_opts["cookiefile"] == "C:/secure/youtube-cookies.txt"
+            assert ydl_opts["ignore_no_formats_error"] is True
+            assert "extractor_args" not in ydl_opts
+
+    @pytest.mark.asyncio
     async def test_missing_required_capability_fails_before_youtube_call(self):
         from shared.worker.base_worker import WorkerStatus
 
@@ -329,6 +359,40 @@ class TestAgeGatedWorkerCapability:
             assert "age_gated" in result.message
             mock_failed.assert_called_once()
             mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_age_gated_retry_bypasses_prior_no_captions_short_circuit(self, monkeypatch):
+        from shared.config import refresh_settings
+        from shared.worker.base_worker import WorkerStatus
+
+        from transcribe.worker import TranscribeMessage, TranscribeWorker
+
+        monkeypatch.setenv("TRANSCRIBE_CAPABILITIES", "age_gated")
+        refresh_settings()
+
+        worker = TranscribeWorker()
+        message = TranscribeMessage(
+            job_id="test-job-id",
+            video_id="test-video-id",
+            youtube_video_id="age_gated_video",
+            correlation_id="test-correlation",
+            required_capabilities=["age_gated"],
+        )
+
+        with (
+            patch("transcribe.worker.mark_job_running", new_callable=AsyncMock),
+            patch("transcribe.worker.mark_job_failed", new_callable=AsyncMock),
+            patch.object(worker, "_has_permanent_no_captions", return_value=True),
+            patch.object(
+                worker, "_fetch_transcript_with_timestamps_and_text", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = (None, None)
+
+            result = await worker.process_message(message, "test-correlation")
+
+            assert result.status == WorkerStatus.FAILED
+            mock_fetch.assert_called_once_with("age_gated_video")
 
     @pytest.mark.asyncio
     async def test_age_gated_error_marks_job_failed_with_clear_message(self):

--- a/services/workers/transcribe/worker.py
+++ b/services/workers/transcribe/worker.py
@@ -323,7 +323,9 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
 
             # Short-circuit: if a prior job already determined this video has no captions,
             # fail immediately instead of hitting YouTube (which may rate-limit us again).
-            if await self._has_permanent_no_captions(message.video_id):
+            if "age_gated" not in (message.required_capabilities or []) and (
+                await self._has_permanent_no_captions(message.video_id)
+            ):
                 error_msg = (
                     "No transcript available for this video. "
                     "This video does not have captions or auto-generated subtitles on YouTube. "
@@ -635,6 +637,9 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
 
             ydl_opts = {
                 "skip_download": True,  # Don't download video/audio
+                # Some age-gated videos expose captions but no playable video formats
+                # to yt-dlp when using authenticated cookies. We only need subtitles.
+                "ignore_no_formats_error": True,
                 "writesubtitles": True,
                 "writeautomaticsub": True,
                 "subtitleslangs": ["en"],
@@ -659,6 +664,9 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 # Authenticated YouTube access is only enabled on explicit age-gated workers.
                 **self._get_yt_dlp_auth_opts(),
             }
+
+            if self._settings.yt_dlp.has_authentication and self.can_process_age_gated:
+                ydl_opts.pop("extractor_args", None)
 
             logger.info(
                 "Starting subtitle download with rate limit delay",


### PR DESCRIPTION
## Summary
- allow explicit age-gated transcript recovery to bypass stale prior no-caption short-circuiting
- let yt-dlp download subtitles when age-gated pages expose captions but no playable formats
- avoid forcing the cookie-incompatible android_vr client for authenticated age-gated workers
- add regressions for the subtitle-only options and age-gated retry path

## Verification
- `./scripts/run-tests.ps1 -Component workers` => 108 passed
- `./scripts/run-tests.ps1` => worker-only selective run, 108 passed
- `python -m pre_commit run --all-files --verbose` => passed
- Manual PROD recovery: downloaded `foYNUVFoZe0` transcript with exported cookies, stored transcript and segments blobs, job succeeded, transcript-only skipped AI queue