### PR TITLE
Move video artifacts to self-contained library blob layout

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -37,7 +37,9 @@ test.describe('Core User Flows @smoke', () => {
 
     test('Browse Library CTA navigates to library @smoke', async ({ page }) => {
       await page.goto('/', { timeout: 60_000 });
-      await page.getByRole('link', { name: /Browse Library/i }).click();
+      const browseLibraryCta = page.locator('main a[href="/library"]').first();
+      await expect(browseLibraryCta).toBeVisible();
+      await browseLibraryCta.click();
       await expect(page).toHaveURL(/\/library\/?(?:[?#].*)?$/, { timeout: 15_000 });
       await expect(page.locator('main')).toBeVisible();
     });

--- a/infra/terraform/environments/prod/storage.tf
+++ b/infra/terraform/environments/prod/storage.tf
@@ -13,6 +13,7 @@ module "storage" {
   account_replication_type = "GRS"
 
   containers = [
+    { name = "library" },
     { name = "transcripts" },
     { name = "summaries" },
     { name = "embeddings" }

--- a/services/api/src/api/main.py
+++ b/services/api/src/api/main.py
@@ -69,6 +69,9 @@ except ImportError:
         raise NotImplementedError("Database not available in fallback mode")
 
 
+logger = get_logger(__name__)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan handler for startup/shutdown events."""
@@ -76,7 +79,6 @@ async def lifespan(app: FastAPI):
     import os
     from datetime import datetime
 
-    logger = get_logger(__name__)
     settings = get_settings()
 
     # Store startup timestamp for uptime calculation (T181b)
@@ -272,14 +274,36 @@ def create_app() -> FastAPI:
     setup_agui_endpoint(app)
 
     # Instrument FastAPI with OpenTelemetry (T185a)
+    _instrument_fastapi_safely(app)
+
+    return app
+
+
+def _instrument_fastapi_safely(app: FastAPI) -> None:
+    """Instrument FastAPI unless registered route wrappers are incompatible.
+
+    The AG-UI integration registers FastAPI ``_IncludedRouter`` wrapper objects on
+    newer FastAPI versions. Current OpenTelemetry FastAPI instrumentation assumes
+    every route object has ``.path`` and raises ``AttributeError`` for browser
+    preflight requests when those wrappers are present.
+    """
+    incompatible_routes = [
+        type(route).__name__ for route in app.routes if not hasattr(route, "path")
+    ]
+    if incompatible_routes:
+        logger.warning(
+            "Skipping FastAPI OpenTelemetry instrumentation because route wrappers "
+            "are incompatible: %s",
+            incompatible_routes,
+        )
+        return
+
     try:
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
         FastAPIInstrumentor.instrument_app(app)
     except ImportError:
         pass  # OpenTelemetry instrumentation not available
-
-    return app
 
 
 async def http_exception_handler(

--- a/services/api/src/api/routes/videos.py
+++ b/services/api/src/api/routes/videos.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # Import shared modules
 try:
     from shared.blob.client import (
+        LIBRARY_CONTAINER,
         SUMMARIES_CONTAINER,
         TRANSCRIPTS_CONTAINER,
         extract_blob_name_from_uri,
@@ -37,6 +38,7 @@ except ImportError:
         raise NotImplementedError("Blob URI helper not available")
 
     Artifact = None
+    LIBRARY_CONTAINER = "library"
     TRANSCRIPTS_CONTAINER = "transcripts"
     SUMMARIES_CONTAINER = "summaries"
 
@@ -70,12 +72,20 @@ def get_video_service(session: AsyncSession = Depends(get_session)) -> VideoServ
     return VideoService(session)
 
 
-async def get_artifact_blob_name(
+def _extract_artifact_ref(blob_uri: str, default_container: str) -> tuple[str, str]:
+    for container_name in [LIBRARY_CONTAINER, TRANSCRIPTS_CONTAINER, SUMMARIES_CONTAINER]:
+        marker = f"/{container_name}/"
+        if marker in blob_uri:
+            return container_name, extract_blob_name_from_uri(blob_uri, container_name)
+    return default_container, extract_blob_name_from_uri(blob_uri, default_container)
+
+
+async def get_artifact_blob_ref(
     session: AsyncSession,
     video_id: UUID,
     artifact_type: str,
-    container_name: str,
-) -> str | None:
+    default_container: str,
+) -> tuple[str, str] | None:
     """Get the blob name recorded for a video artifact."""
     if Artifact is None:
         return None
@@ -89,7 +99,7 @@ async def get_artifact_blob_name(
     if not blob_uri:
         return None
 
-    return extract_blob_name_from_uri(blob_uri, container_name)
+    return _extract_artifact_ref(blob_uri, default_container)
 
 
 def _get_reprocess_start_stage(stages: list[str] | None) -> JobType:
@@ -409,22 +419,27 @@ async def get_video_transcript(
     # Prefer the persisted artifact URI. It matches how completed videos are stored
     # and avoids probing stale path formats that can be slow when missing.
     channel_name = video.channel.name if video.channel else "unknown-channel"
-    artifact_blob_name = await get_artifact_blob_name(
+    artifact_blob_ref = await get_artifact_blob_ref(
         service.session,
         video_id,
         "transcript",
         TRANSCRIPTS_CONTAINER,
     )
     fallback_blob_name = get_transcript_blob_path(channel_name, video.youtube_video_id)
-    blob_names = [name for name in [artifact_blob_name, fallback_blob_name] if name]
+    blob_refs = [
+        (LIBRARY_CONTAINER, fallback_blob_name),
+        artifact_blob_ref,
+        (TRANSCRIPTS_CONTAINER, fallback_blob_name),
+    ]
 
     blob_client = get_blob_client()
     last_error: Exception | None = None
-    for index, blob_name in enumerate(dict.fromkeys(blob_names)):
+    for index, blob_ref in enumerate(dict.fromkeys(ref for ref in blob_refs if ref)):
+        container_name, blob_name = blob_ref
         try:
-            if index > 0 and not blob_client.blob_exists(TRANSCRIPTS_CONTAINER, blob_name):
+            if index > 0 and not blob_client.blob_exists(container_name, blob_name):
                 continue
-            content = blob_client.download_blob(TRANSCRIPTS_CONTAINER, blob_name)
+            content = blob_client.download_blob(container_name, blob_name)
             return PlainTextResponse(content.decode("utf-8"), media_type="text/plain")
         except Exception as e:
             last_error = e
@@ -466,22 +481,27 @@ async def get_video_summary(
     # Prefer the persisted artifact URI. It matches how completed videos are stored
     # and avoids probing stale path formats that can be slow when missing.
     channel_name = video.channel.name if video.channel else "unknown-channel"
-    artifact_blob_name = await get_artifact_blob_name(
+    artifact_blob_ref = await get_artifact_blob_ref(
         service.session,
         video_id,
         "summary",
         SUMMARIES_CONTAINER,
     )
     fallback_blob_name = get_summary_blob_path(channel_name, video.youtube_video_id)
-    blob_names = [name for name in [artifact_blob_name, fallback_blob_name] if name]
+    blob_refs = [
+        (LIBRARY_CONTAINER, fallback_blob_name),
+        artifact_blob_ref,
+        (SUMMARIES_CONTAINER, fallback_blob_name),
+    ]
 
     blob_client = get_blob_client()
     last_error: Exception | None = None
-    for index, blob_name in enumerate(dict.fromkeys(blob_names)):
+    for index, blob_ref in enumerate(dict.fromkeys(ref for ref in blob_refs if ref)):
+        container_name, blob_name = blob_ref
         try:
-            if index > 0 and not blob_client.blob_exists(SUMMARIES_CONTAINER, blob_name):
+            if index > 0 and not blob_client.blob_exists(container_name, blob_name):
                 continue
-            content = blob_client.download_blob(SUMMARIES_CONTAINER, blob_name)
+            content = blob_client.download_blob(container_name, blob_name)
             return PlainTextResponse(content.decode("utf-8"), media_type="text/markdown")
         except Exception as e:
             last_error = e

--- a/services/api/src/api/services/library_service.py
+++ b/services/api/src/api/services/library_service.py
@@ -9,7 +9,12 @@ from sqlalchemy.orm import contains_eager, noload, selectinload
 
 # Import shared modules
 try:
-    from shared.blob.client import SUMMARIES_CONTAINER, extract_blob_name_from_uri, get_blob_client
+    from shared.blob.client import (
+        LIBRARY_CONTAINER,
+        SUMMARIES_CONTAINER,
+        extract_blob_name_from_uri,
+        get_blob_client,
+    )
     from shared.db.models import (
         Artifact,
         Channel,
@@ -36,6 +41,7 @@ except ImportError as e:
     VideoFacet = Any
     get_blob_client = None
     SUMMARIES_CONTAINER = "summaries"
+    LIBRARY_CONTAINER = "library"
 
     def extract_blob_name_from_uri(blob_uri: str, container_name: str) -> str:
         parts = blob_uri.split(f"/{container_name}/")
@@ -310,7 +316,7 @@ class LibraryService:
         summary_artifact = None
         transcript_artifact = None
         summary_text = None
-        summary_blob_name = None
+        summary_blob_ref = None
 
         for artifact in video.artifacts:
             artifact_info = ArtifactInfo(
@@ -326,12 +332,17 @@ class LibraryService:
                 # blob_uri format: http://host/account/container/{video_id}/{youtube_video_id}_summary.md
                 # We need to extract: {video_id}/{youtube_video_id}_summary.md (everything after container name)
                 if artifact.blob_uri:
-                    summary_blob_name = extract_blob_name_from_uri(
-                        artifact.blob_uri,
-                        SUMMARIES_CONTAINER,
+                    container = (
+                        LIBRARY_CONTAINER
+                        if f"/{LIBRARY_CONTAINER}/" in artifact.blob_uri
+                        else SUMMARIES_CONTAINER
+                    )
+                    summary_blob_ref = (
+                        container,
+                        extract_blob_name_from_uri(artifact.blob_uri, container),
                     )
                 else:
-                    summary_blob_name = None
+                    summary_blob_ref = None
             elif artifact.artifact_type == "transcript":
                 transcript_artifact = artifact_info
 
@@ -342,10 +353,11 @@ class LibraryService:
         )
 
         # Fetch summary content from blob storage if available
-        if summary_blob_name and get_blob_client is not None:
+        if summary_blob_ref and get_blob_client is not None:
             try:
                 blob_client = get_blob_client()
-                summary_bytes = blob_client.download_blob(SUMMARIES_CONTAINER, summary_blob_name)
+                container, blob_name = summary_blob_ref
+                summary_bytes = blob_client.download_blob(container, blob_name)
                 summary_text = summary_bytes.decode("utf-8")
             except Exception as e:
                 logger.warning(f"Failed to fetch summary from blob: {e}")

--- a/services/api/tests/test_agent_integration.py
+++ b/services/api/tests/test_agent_integration.py
@@ -6,6 +6,20 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+def _route_paths(app) -> list[str]:
+    """Collect paths from concrete routes and FastAPI included-router wrappers."""
+    paths: list[str] = []
+    for route in app.routes:
+        if hasattr(route, "path"):
+            paths.append(route.path)
+        original_router = getattr(route, "original_router", None)
+        if original_router:
+            paths.extend(
+                nested.path for nested in original_router.routes if hasattr(nested, "path")
+            )
+    return paths
+
+
 @pytest.mark.unit  # run in CI without live DB
 def test_agent_routes_registered():
     """All 7 agent routes are registered in the app."""
@@ -13,7 +27,7 @@ def test_agent_routes_registered():
     from api.main import create_app
 
     app = create_app()
-    paths = [r.path for r in app.routes]
+    paths = _route_paths(app)
     agent_paths = [p for p in paths if "/agent/" in p or p.startswith("/api/v1/agent")]
     assert len(agent_paths) >= 7, f"Expected 7+ agent routes, got {len(agent_paths)}: {agent_paths}"
 

--- a/services/api/tests/test_agent_integration.py
+++ b/services/api/tests/test_agent_integration.py
@@ -42,3 +42,23 @@ def test_agent_requires_auth():
     client = TestClient(app, raise_server_exceptions=False)
     resp = client.post("/api/v1/agent/search/semantic", json={"query": "test"})
     assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_options_preflight_does_not_crash_with_agui_routes():
+    """Browser preflight requests must not crash when AG-UI routes are registered."""
+    os.environ["API_KEY"] = "test-key"
+    from api.main import create_app
+
+    app = create_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.options(
+        "/api/v1/library/videos",
+        headers={
+            "Origin": "https://preview.example.test",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+
+    assert resp.status_code != 500

--- a/services/api/tests/test_agents.py
+++ b/services/api/tests/test_agents.py
@@ -40,6 +40,20 @@ requires_agent_framework_ag_ui = pytest.mark.skipif(
 )
 
 
+def _route_paths(app: FastAPI) -> list[str]:
+    """Collect paths from concrete routes and FastAPI included-router wrappers."""
+    paths: list[str] = []
+    for route in app.routes:
+        if hasattr(route, "path"):
+            paths.append(route.path)
+        original_router = getattr(route, "original_router", None)
+        if original_router:
+            paths.extend(
+                nested.path for nested in original_router.routes if hasattr(nested, "path")
+            )
+    return paths
+
+
 # =============================================================================
 # Test: Agent Framework Availability (REQUIRED for CopilotKit)
 # =============================================================================
@@ -561,7 +575,7 @@ class TestFullApplicationIntegration:
         app = create_app()
 
         # Get all registered route paths
-        route_paths = [route.path for route in app.routes]
+        route_paths = _route_paths(app)
 
         assert "/api/copilotkit" in route_paths, "Main app should register /api/copilotkit route"
         assert "/api/copilotkit/info" in route_paths, (

--- a/services/shared/shared/blob/__init__.py
+++ b/services/shared/shared/blob/__init__.py
@@ -1,6 +1,7 @@
 """Blob storage client module."""
 
 from .client import (
+    LIBRARY_CONTAINER,
     SUMMARIES_CONTAINER,
     TRANSCRIPTS_CONTAINER,
     BlobClient,
@@ -10,14 +11,27 @@ from .client import (
     extract_blob_name_from_uri,
     get_blob_client,
     get_connection_string,
+    get_metadata_blob_path,
     get_segments_blob_path,
     get_summary_blob_path,
     get_transcript_blob_path,
+    get_video_folder_path,
     sanitize_channel_name,
+)
+from .metadata import (
+    ARTIFACT_CONTENT_TYPES,
+    METADATA_SCHEMA_VERSION,
+    artifact_path,
+    build_video_metadata,
+    metadata_artifact_ref,
+    write_video_metadata,
 )
 
 __all__ = [
+    "ARTIFACT_CONTENT_TYPES",
     "BlobClient",
+    "LIBRARY_CONTAINER",
+    "METADATA_SCHEMA_VERSION",
     "SUMMARIES_CONTAINER",
     "TRANSCRIPTS_CONTAINER",
     "compute_content_hash",
@@ -26,8 +40,14 @@ __all__ = [
     "extract_blob_name_from_uri",
     "get_blob_client",
     "get_connection_string",
+    "get_metadata_blob_path",
     "get_segments_blob_path",
     "get_summary_blob_path",
     "get_transcript_blob_path",
+    "get_video_folder_path",
     "sanitize_channel_name",
+    "artifact_path",
+    "build_video_metadata",
+    "metadata_artifact_ref",
+    "write_video_metadata",
 ]

--- a/services/shared/shared/blob/client.py
+++ b/services/shared/shared/blob/client.py
@@ -13,6 +13,7 @@ from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
 from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 # Default container names
+LIBRARY_CONTAINER = "library"
 TRANSCRIPTS_CONTAINER = "transcripts"
 SUMMARIES_CONTAINER = "summaries"
 
@@ -62,6 +63,12 @@ def sanitize_channel_name(channel_name: str) -> str:
     return name
 
 
+def get_video_folder_path(channel_name: str, youtube_video_id: str) -> str:
+    """Get the canonical self-contained folder path for a video."""
+    sanitized = sanitize_channel_name(channel_name)
+    return f"{sanitized}/{youtube_video_id}"
+
+
 def get_transcript_blob_path(channel_name: str, youtube_video_id: str) -> str:
     """Get the blob path for a transcript file.
 
@@ -75,8 +82,7 @@ def get_transcript_blob_path(channel_name: str, youtube_video_id: str) -> str:
     Returns:
         The blob path for the transcript file.
     """
-    sanitized = sanitize_channel_name(channel_name)
-    return f"{sanitized}/{youtube_video_id}/transcript.txt"
+    return f"{get_video_folder_path(channel_name, youtube_video_id)}/transcript.txt"
 
 
 def get_segments_blob_path(channel_name: str, youtube_video_id: str) -> str:
@@ -92,8 +98,7 @@ def get_segments_blob_path(channel_name: str, youtube_video_id: str) -> str:
     Returns:
         The blob path for the segments file.
     """
-    sanitized = sanitize_channel_name(channel_name)
-    return f"{sanitized}/{youtube_video_id}/segments.json"
+    return f"{get_video_folder_path(channel_name, youtube_video_id)}/segments.json"
 
 
 def get_summary_blob_path(channel_name: str, youtube_video_id: str) -> str:
@@ -109,8 +114,12 @@ def get_summary_blob_path(channel_name: str, youtube_video_id: str) -> str:
     Returns:
         The blob path for the summary file.
     """
-    sanitized = sanitize_channel_name(channel_name)
-    return f"{sanitized}/{youtube_video_id}/summary.md"
+    return f"{get_video_folder_path(channel_name, youtube_video_id)}/summary.md"
+
+
+def get_metadata_blob_path(channel_name: str, youtube_video_id: str) -> str:
+    """Get the blob path for a video metadata file."""
+    return f"{get_video_folder_path(channel_name, youtube_video_id)}/metadata.json"
 
 
 def extract_blob_name_from_uri(blob_uri: str, container_name: str) -> str:

--- a/services/shared/shared/blob/metadata.py
+++ b/services/shared/shared/blob/metadata.py
@@ -1,0 +1,159 @@
+"""Metadata helpers for self-contained video blob folders."""
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from azure.core.exceptions import ResourceNotFoundError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from shared.db.models import Artifact, Video
+
+from .client import (
+    LIBRARY_CONTAINER,
+    BlobClient,
+    compute_content_hash,
+    get_blob_client,
+    get_metadata_blob_path,
+    get_segments_blob_path,
+    get_summary_blob_path,
+    get_transcript_blob_path,
+    sanitize_channel_name,
+)
+
+METADATA_SCHEMA_VERSION = 1
+ARTIFACT_CONTENT_TYPES = {
+    "metadata": "application/json; charset=utf-8",
+    "segments": "application/json; charset=utf-8",
+    "summary": "text/markdown; charset=utf-8",
+    "transcript": "text/plain; charset=utf-8",
+}
+
+
+def _dt(value: Any) -> str | None:
+    return value.isoformat() if value else None
+
+
+def artifact_path(channel_name: str, youtube_video_id: str, artifact_type: str) -> str:
+    """Return the canonical library path for a known artifact type."""
+    if artifact_type == "transcript":
+        return get_transcript_blob_path(channel_name, youtube_video_id)
+    if artifact_type == "segments":
+        return get_segments_blob_path(channel_name, youtube_video_id)
+    if artifact_type == "summary":
+        return get_summary_blob_path(channel_name, youtube_video_id)
+    if artifact_type == "metadata":
+        return get_metadata_blob_path(channel_name, youtube_video_id)
+    raise ValueError(f"Unsupported artifact type: {artifact_type}")
+
+
+def build_video_metadata(
+    video: Video,
+    artifacts: list[Artifact] | None = None,
+    *,
+    extra_artifacts: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the metadata.json payload for a video folder."""
+    channel = video.channel
+    channel_name = channel.name if channel else "unknown-channel"
+    youtube_video_id = video.youtube_video_id
+    artifact_entries: dict[str, dict[str, Any]] = {}
+
+    for artifact in artifacts or []:
+        artifact_type = artifact.artifact_type
+        artifact_entries[artifact_type] = {
+            "path": artifact_path(channel_name, youtube_video_id, artifact_type),
+            "blob_uri": artifact.blob_uri,
+            "content_length": artifact.content_length,
+            "content_hash": artifact.content_hash,
+            "content_type": ARTIFACT_CONTENT_TYPES.get(artifact_type),
+            "updated_at": _dt(artifact.created_at),
+        }
+
+    for artifact_type, data in (extra_artifacts or {}).items():
+        artifact_entries[artifact_type] = {
+            "path": artifact_path(channel_name, youtube_video_id, artifact_type),
+            "content_type": ARTIFACT_CONTENT_TYPES.get(artifact_type),
+            **data,
+        }
+
+    return {
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "video_id": str(video.video_id),
+        "youtube_video_id": youtube_video_id,
+        "youtube_url": f"https://www.youtube.com/watch?v={youtube_video_id}",
+        "title": video.title,
+        "description": video.description,
+        "duration": video.duration,
+        "publish_date": _dt(video.publish_date),
+        "thumbnail_url": video.thumbnail_url,
+        "processing_status": video.processing_status,
+        "processing_mode": getattr(video, "processing_mode", None),
+        "channel": {
+            "channel_id": str(channel.channel_id) if channel else None,
+            "youtube_channel_id": channel.youtube_channel_id if channel else None,
+            "name": channel.name if channel else None,
+            "slug": sanitize_channel_name(channel_name),
+            "description": channel.description if channel else None,
+            "thumbnail_url": channel.thumbnail_url if channel else None,
+        },
+        "artifacts": artifact_entries,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+
+
+async def write_video_metadata(
+    session: AsyncSession,
+    video_id: str,
+    *,
+    blob_client: BlobClient | None = None,
+    extra_artifacts: dict[str, dict[str, Any]] | None = None,
+) -> str | None:
+    """Write metadata.json for a video using current SQL metadata and artifacts."""
+    video_uuid = UUID(video_id) if isinstance(video_id, str) else video_id
+    result = await session.execute(
+        select(Video).options(selectinload(Video.channel)).where(Video.video_id == video_uuid)
+    )
+    video = result.scalar_one_or_none()
+    if not video:
+        return None
+
+    artifacts_result = await session.execute(
+        select(Artifact).where(Artifact.video_id == video_uuid)
+    )
+    artifacts = list(artifacts_result.scalars().all())
+    channel_name = video.channel.name if video.channel else "unknown-channel"
+    blob_name = get_metadata_blob_path(channel_name, video.youtube_video_id)
+    client = blob_client or get_blob_client()
+
+    payload = build_video_metadata(video, artifacts, extra_artifacts=extra_artifacts)
+    try:
+        existing = json.loads(client.download_blob(LIBRARY_CONTAINER, blob_name).decode("utf-8"))
+        existing_artifacts = existing.get("artifacts") or {}
+        payload["artifacts"] = {
+            **existing_artifacts,
+            **payload["artifacts"],
+        }
+    except (ResourceNotFoundError, json.JSONDecodeError, UnicodeDecodeError):
+        pass
+
+    content = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    return client.upload_blob(
+        LIBRARY_CONTAINER,
+        blob_name,
+        content,
+        content_type=ARTIFACT_CONTENT_TYPES["metadata"],
+    )
+
+
+def metadata_artifact_ref(content: bytes, blob_uri: str) -> dict[str, Any]:
+    """Build artifact details for metadata.json when content was just written."""
+    return {
+        "blob_uri": blob_uri,
+        "content_length": len(content),
+        "content_hash": compute_content_hash(content),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }

--- a/services/shared/tests/test_blob_helpers.py
+++ b/services/shared/tests/test_blob_helpers.py
@@ -6,11 +6,15 @@ import pytest
 from azure.core.exceptions import ResourceNotFoundError
 
 from shared.blob.client import (
+    LIBRARY_CONTAINER,
     SUMMARIES_CONTAINER,
     BlobClient,
     extract_blob_name_from_uri,
+    get_metadata_blob_path,
     get_segments_blob_path,
+    get_summary_blob_path,
     get_transcript_blob_path,
+    get_video_folder_path,
     sanitize_channel_name,
 )
 
@@ -84,6 +88,15 @@ class TestGetTranscriptBlobPath:
         assert result == "my-channel/video123/transcript.txt"
 
 
+class TestGetVideoFolderPath:
+    """Tests for canonical self-contained video folder paths."""
+
+    def test_basic_folder_path(self):
+        """Test canonical folder path generation."""
+        result = get_video_folder_path("Mark Wildman", "abc123")
+        assert result == "mark-wildman/abc123"
+
+
 class TestGetSegmentsBlobPath:
     """Tests for get_segments_blob_path function."""
 
@@ -96,6 +109,24 @@ class TestGetSegmentsBlobPath:
         """Test that YouTube video ID is preserved exactly."""
         result = get_segments_blob_path("Channel", "ABC123xyz")
         assert result == "channel/ABC123xyz/segments.json"
+
+
+class TestGetSummaryBlobPath:
+    """Tests for get_summary_blob_path function."""
+
+    def test_basic_path(self):
+        """Test basic summary path generation."""
+        result = get_summary_blob_path("Test Channel", "dQw4w9WgXcQ")
+        assert result == "test-channel/dQw4w9WgXcQ/summary.md"
+
+
+class TestGetMetadataBlobPath:
+    """Tests for get_metadata_blob_path function."""
+
+    def test_basic_path(self):
+        """Test basic metadata path generation."""
+        result = get_metadata_blob_path("Test Channel", "dQw4w9WgXcQ")
+        assert result == "test-channel/dQw4w9WgXcQ/metadata.json"
 
 
 class TestExtractBlobNameFromUri:
@@ -117,6 +148,16 @@ class TestExtractBlobNameFromUri:
         assert extract_blob_name_from_uri("video_summary.md", SUMMARIES_CONTAINER) == (
             "video_summary.md"
         )
+
+    def test_extracts_library_blob_path(self):
+        """Test extracting canonical library blob paths."""
+        blob_uri = (
+            "https://account.blob.core.windows.net/library/mark-wildman/dQw4w9WgXcQ/transcript.txt"
+        )
+
+        result = extract_blob_name_from_uri(blob_uri, LIBRARY_CONTAINER)
+
+        assert result == "mark-wildman/dQw4w9WgXcQ/transcript.txt"
 
 
 class TestBlobClientDownload:

--- a/services/workers/backup/migrate_library_layout.py
+++ b/services/workers/backup/migrate_library_layout.py
@@ -1,0 +1,366 @@
+"""Migrate legacy blob artifacts into the canonical library container."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from azure.core.exceptions import ResourceNotFoundError
+from shared.blob import (
+    ARTIFACT_CONTENT_TYPES,
+    LIBRARY_CONTAINER,
+    SUMMARIES_CONTAINER,
+    TRANSCRIPTS_CONTAINER,
+    BlobClient,
+    compute_content_hash,
+    get_blob_client,
+    get_segments_blob_path,
+    get_summary_blob_path,
+    get_transcript_blob_path,
+    sanitize_channel_name,
+    write_video_metadata,
+)
+from shared.db.connection import get_db
+from shared.db.models import Artifact, Channel, Video
+from shared.logging.config import get_logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ArtifactMigrationResult:
+    """Result for a single artifact copy attempt."""
+
+    artifact_type: str
+    source_container: str
+    destination_container: str
+    blob_path: str
+    status: str
+    bytes_copied: int = 0
+    source_hash: str | None = None
+    destination_hash: str | None = None
+    source_blob_uri: str | None = None
+    destination_blob_uri: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class VideoMigrationResult:
+    """Result for one migrated video folder."""
+
+    video_id: str
+    youtube_video_id: str
+    channel_slug: str
+    status: str
+    artifacts: list[ArtifactMigrationResult] = field(default_factory=list)
+    verified_legacy_blobs: list[tuple[str, str]] = field(default_factory=list)
+    metadata_written: bool = False
+    deleted_legacy_blobs: int = 0
+    error: str | None = None
+
+
+@dataclass
+class MigrationReport:
+    """Aggregate migration report."""
+
+    dry_run: bool
+    delete_verified: bool
+    channels: list[str]
+    videos_seen: int = 0
+    videos_migrated: int = 0
+    artifacts_copied: int = 0
+    artifacts_skipped: int = 0
+    artifacts_missing: int = 0
+    artifacts_failed: int = 0
+    legacy_blobs_deleted: int = 0
+    videos: list[VideoMigrationResult] = field(default_factory=list)
+
+
+LEGACY_ARTIFACTS: dict[str, tuple[str, Any]] = {
+    "transcript": (TRANSCRIPTS_CONTAINER, get_transcript_blob_path),
+    "segments": (TRANSCRIPTS_CONTAINER, get_segments_blob_path),
+    "summary": (SUMMARIES_CONTAINER, get_summary_blob_path),
+}
+
+
+class LibraryLayoutMigrator:
+    """Copy legacy artifacts into per-video library folders."""
+
+    def __init__(
+        self,
+        *,
+        dry_run: bool,
+        delete_verified: bool,
+        channels: list[str],
+        blob_client: BlobClient | None = None,
+    ) -> None:
+        self.dry_run = dry_run
+        self.delete_verified = delete_verified
+        self.channels = [sanitize_channel_name(channel) for channel in channels]
+        self.blob_client = blob_client or get_blob_client()
+
+    async def run(self) -> MigrationReport:
+        """Run the migration and return an in-memory report."""
+        report = MigrationReport(
+            dry_run=self.dry_run,
+            delete_verified=self.delete_verified,
+            channels=self.channels,
+        )
+        db = get_db()
+        async with db.session() as session:
+            videos = await self._load_videos(session)
+
+        report.videos_seen = len(videos)
+        for video in videos:
+            async with db.session() as session:
+                result = await self._migrate_video(session, video)
+            self._delete_verified_legacy_blobs(result)
+            self._apply_video_result(report, result)
+            logger.info(
+                "Library layout migration video processed",
+                channel_slug=result.channel_slug,
+                youtube_video_id=result.youtube_video_id,
+                status=result.status,
+            )
+        return report
+
+    async def _load_videos(self, session: AsyncSession) -> list[Video]:
+        stmt = (
+            select(Video)
+            .options(selectinload(Video.channel))
+            .join(Channel)
+            .order_by(Channel.name.asc(), Video.publish_date.asc())
+        )
+        if self.channels:
+            stmt = stmt.where(Channel.name.is_not(None))
+        result = await session.execute(stmt)
+        videos = list(result.scalars().all())
+        if not self.channels:
+            return videos
+        return [
+            video
+            for video in videos
+            if video.channel
+            and (
+                sanitize_channel_name(video.channel.name) in self.channels
+                or video.channel.youtube_channel_id.lower() in self.channels
+            )
+        ]
+
+    async def _migrate_video(
+        self,
+        session: AsyncSession,
+        detached_video: Video,
+    ) -> VideoMigrationResult:
+        video_result = await session.execute(
+            select(Video)
+            .options(selectinload(Video.channel))
+            .where(Video.video_id == detached_video.video_id)
+        )
+        video = video_result.scalar_one()
+        channel_name = video.channel.name if video.channel else "unknown-channel"
+        channel_slug = sanitize_channel_name(channel_name)
+        result = VideoMigrationResult(
+            video_id=str(video.video_id),
+            youtube_video_id=video.youtube_video_id,
+            channel_slug=channel_slug,
+            status="pending",
+        )
+
+        artifact_rows = await self._load_artifacts(session, video)
+
+        try:
+            for artifact_type, (source_container, path_helper) in LEGACY_ARTIFACTS.items():
+                blob_path = path_helper(channel_name, video.youtube_video_id)
+                artifact_result = self._copy_and_verify_artifact(
+                    artifact_type,
+                    source_container,
+                    blob_path,
+                )
+                result.artifacts.append(artifact_result)
+                if artifact_result.status == "copied":
+                    result.verified_legacy_blobs.append((source_container, blob_path))
+                    self._update_artifact_row(artifact_rows, artifact_type, artifact_result)
+
+            if not self.dry_run:
+                await session.flush()
+                metadata_uri = await write_video_metadata(
+                    session,
+                    str(video.video_id),
+                    blob_client=self.blob_client,
+                    extra_artifacts=self._metadata_artifacts(result),
+                )
+                result.metadata_written = bool(metadata_uri)
+
+            result.status = "succeeded" if self._video_verified(result) else "partial"
+            return result
+        except Exception as exc:
+            result.status = "failed"
+            result.error = str(exc)
+            logger.exception(
+                "Library layout migration failed for video",
+                video_id=str(video.video_id),
+                youtube_video_id=video.youtube_video_id,
+            )
+            raise
+
+    async def _load_artifacts(
+        self,
+        session: AsyncSession,
+        video: Video,
+    ) -> dict[str, Artifact]:
+        rows = await session.execute(select(Artifact).where(Artifact.video_id == video.video_id))
+        return {artifact.artifact_type: artifact for artifact in rows.scalars().all()}
+
+    def _copy_and_verify_artifact(
+        self,
+        artifact_type: str,
+        source_container: str,
+        blob_path: str,
+    ) -> ArtifactMigrationResult:
+        result = ArtifactMigrationResult(
+            artifact_type=artifact_type,
+            source_container=source_container,
+            destination_container=LIBRARY_CONTAINER,
+            blob_path=blob_path,
+            status="pending",
+        )
+        try:
+            source_content = self.blob_client.download_blob(source_container, blob_path)
+        except ResourceNotFoundError:
+            result.status = "missing"
+            return result
+
+        source_hash = compute_content_hash(source_content)
+        result.source_hash = source_hash
+        result.bytes_copied = len(source_content)
+        result.source_blob_uri = self.blob_client.get_blob_url(source_container, blob_path)
+
+        if self.dry_run:
+            result.status = "would_copy"
+            return result
+
+        result.destination_blob_uri = self.blob_client.upload_blob(
+            LIBRARY_CONTAINER,
+            blob_path,
+            source_content,
+            content_type=ARTIFACT_CONTENT_TYPES[artifact_type],
+            overwrite=True,
+        )
+        destination_content = self.blob_client.download_blob(LIBRARY_CONTAINER, blob_path)
+        destination_hash = compute_content_hash(destination_content)
+        result.destination_hash = destination_hash
+        if destination_hash != source_hash:
+            result.status = "failed"
+            result.error = "Destination hash does not match source hash"
+            return result
+
+        result.status = "copied"
+        return result
+
+    def _update_artifact_row(
+        self,
+        artifact_rows: dict[str, Artifact],
+        artifact_type: str,
+        artifact_result: ArtifactMigrationResult,
+    ) -> None:
+        artifact = artifact_rows.get(artifact_type)
+        if not artifact or not artifact_result.destination_blob_uri:
+            return
+        artifact.blob_uri = artifact_result.destination_blob_uri
+        artifact.content_hash = artifact_result.destination_hash
+        artifact.content_length = artifact_result.bytes_copied
+
+    @staticmethod
+    def _metadata_artifacts(result: VideoMigrationResult) -> dict[str, dict[str, Any]]:
+        artifacts: dict[str, dict[str, Any]] = {}
+        for artifact in result.artifacts:
+            if artifact.status != "copied" or not artifact.destination_blob_uri:
+                continue
+            artifacts[artifact.artifact_type] = {
+                "blob_uri": artifact.destination_blob_uri,
+                "content_length": artifact.bytes_copied,
+                "content_hash": artifact.destination_hash,
+                "updated_at": datetime.now(UTC).isoformat(),
+            }
+        return artifacts
+
+    def _delete_verified_legacy_blobs(self, result: VideoMigrationResult) -> None:
+        """Delete old blobs only after the video transaction has committed."""
+        if self.dry_run or not self.delete_verified or result.status != "succeeded":
+            return
+
+        for container, blob_path in result.verified_legacy_blobs:
+            self.blob_client.delete_blob(container, blob_path)
+            result.deleted_legacy_blobs += 1
+
+    @staticmethod
+    def _video_verified(result: VideoMigrationResult) -> bool:
+        return all(
+            artifact.status in {"copied", "missing", "would_copy"} for artifact in result.artifacts
+        )
+
+    @staticmethod
+    def _apply_video_result(report: MigrationReport, result: VideoMigrationResult) -> None:
+        report.videos.append(result)
+        if result.status == "succeeded":
+            report.videos_migrated += 1
+        report.legacy_blobs_deleted += result.deleted_legacy_blobs
+        for artifact in result.artifacts:
+            if artifact.status == "copied":
+                report.artifacts_copied += 1
+            elif artifact.status == "would_copy":
+                report.artifacts_skipped += 1
+            elif artifact.status == "missing":
+                report.artifacts_missing += 1
+            elif artifact.status == "failed":
+                report.artifacts_failed += 1
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Migrate video blobs into the library container")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Report actions without copying")
+    mode.add_argument("--execute", action="store_true", help="Copy and update verified artifacts")
+    parser.add_argument(
+        "--delete-verified",
+        action="store_true",
+        help="Delete legacy blobs after each video verifies successfully",
+    )
+    parser.add_argument(
+        "--channel",
+        action="append",
+        default=[],
+        help="Limit migration to a channel name, slug, or YouTube channel ID",
+    )
+    return parser.parse_args()
+
+
+async def async_main() -> None:
+    """Run from the command line."""
+    args = parse_args()
+    dry_run = not args.execute
+    migrator = LibraryLayoutMigrator(
+        dry_run=dry_run,
+        delete_verified=bool(args.execute and args.delete_verified),
+        channels=args.channel,
+    )
+    report = await migrator.run()
+    logger.info("Library layout migration completed", report=asdict(report))
+    print(asdict(report))
+
+
+def main() -> None:
+    """Entrypoint."""
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/services/workers/backup/nightly.py
+++ b/services/workers/backup/nightly.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import ContentSettings
 from shared.blob.client import (
+    LIBRARY_CONTAINER,
     SUMMARIES_CONTAINER,
     TRANSCRIPTS_CONTAINER,
     BlobClient,
@@ -386,9 +387,10 @@ class NightlyBackupRunner:
             if transcript_artifact:
                 transcript_ref, copied = await self._ensure_backed_up(
                     index_artifacts,
-                    live_container=TRANSCRIPTS_CONTAINER,
+                    live_container=LIBRARY_CONTAINER,
+                    fallback_container=TRANSCRIPTS_CONTAINER,
                     live_path=get_transcript_blob_path(channel.name, video.youtube_video_id),
-                    backup_path=f"mirror/transcripts/{channel_slug}/{video.youtube_video_id}/transcript.txt",
+                    backup_path=f"mirror/library/{channel_slug}/{video.youtube_video_id}/transcript.txt",
                     artifact=transcript_artifact,
                     artifact_type="transcript",
                     content_type="text/plain; charset=utf-8",
@@ -414,9 +416,10 @@ class NightlyBackupRunner:
             if self.config.include_summaries and summary_artifact:
                 summary_ref, copied = await self._ensure_backed_up(
                     index_artifacts,
-                    live_container=SUMMARIES_CONTAINER,
+                    live_container=LIBRARY_CONTAINER,
+                    fallback_container=SUMMARIES_CONTAINER,
                     live_path=get_summary_blob_path(channel.name, video.youtube_video_id),
-                    backup_path=f"mirror/summaries/{channel_slug}/{video.youtube_video_id}/summary.md",
+                    backup_path=f"mirror/library/{channel_slug}/{video.youtube_video_id}/summary.md",
                     artifact=summary_artifact,
                     artifact_type="summary",
                     content_type="text/markdown; charset=utf-8",
@@ -470,6 +473,7 @@ class NightlyBackupRunner:
         index_artifacts: dict[str, Any],
         *,
         live_container: str,
+        fallback_container: str | None = None,
         live_path: str,
         backup_path: str,
         artifact: Artifact,
@@ -489,6 +493,7 @@ class NightlyBackupRunner:
 
         ref = await self._copy_live_blob(
             live_container=live_container,
+            fallback_container=fallback_container,
             live_path=live_path,
             backup_path=backup_path,
             artifact_type=artifact_type,
@@ -510,23 +515,22 @@ class NightlyBackupRunner:
         force_copy: bool,
     ) -> tuple[dict[str, Any] | None, bool]:
         live_path = get_segments_blob_path(channel_name, youtube_video_id)
-        index_key = f"{TRANSCRIPTS_CONTAINER}/{live_path}"
+        index_key = f"{LIBRARY_CONTAINER}/{live_path}"
         existing = index_artifacts.get(index_key)
         if existing and not force_copy:
             return existing, False
 
         try:
             ref = await self._copy_live_blob(
-                live_container=TRANSCRIPTS_CONTAINER,
+                live_container=LIBRARY_CONTAINER,
+                fallback_container=TRANSCRIPTS_CONTAINER,
                 live_path=live_path,
-                backup_path=f"mirror/transcripts/{channel_slug}/{youtube_video_id}/segments.json",
+                backup_path=f"mirror/library/{channel_slug}/{youtube_video_id}/segments.json",
                 artifact_type="segments",
-                content_type="application/json",
+                content_type="application/json; charset=utf-8",
                 source_content_hash=None,
                 source_content_length=None,
-                source_blob_uri=self.live_blob_client.get_blob_url(
-                    TRANSCRIPTS_CONTAINER, live_path
-                ),
+                source_blob_uri=self.live_blob_client.get_blob_url(LIBRARY_CONTAINER, live_path),
             )
         except ResourceNotFoundError:
             return None, False
@@ -538,6 +542,7 @@ class NightlyBackupRunner:
         self,
         *,
         live_container: str,
+        fallback_container: str | None = None,
         live_path: str,
         backup_path: str,
         artifact_type: str,
@@ -546,7 +551,16 @@ class NightlyBackupRunner:
         source_content_length: int | None,
         source_blob_uri: str | None,
     ) -> dict[str, Any]:
-        content = self.live_blob_client.download_blob(live_container, live_path)
+        source_container = live_container
+        try:
+            content = self.live_blob_client.download_blob(live_container, live_path)
+        except ResourceNotFoundError:
+            if not fallback_container:
+                raise
+            source_container = fallback_container
+            content = self.live_blob_client.download_blob(fallback_container, live_path)
+            source_blob_uri = self.live_blob_client.get_blob_url(fallback_container, live_path)
+
         content_hash = compute_content_hash(content)
         content_length = len(content)
         if source_content_hash and content_hash != source_content_hash:
@@ -570,7 +584,7 @@ class NightlyBackupRunner:
         props = blob_client.get_blob_properties()
         return {
             "artifact_type": artifact_type,
-            "live_container": live_container,
+            "live_container": source_container,
             "live_path": live_path,
             "backup_container": self.config.backup_container,
             "backup_path": backup_path,

--- a/services/workers/embed/worker.py
+++ b/services/workers/embed/worker.py
@@ -15,6 +15,7 @@ except ImportError:
 import sqlalchemy as sa
 
 from shared.blob.client import (
+    LIBRARY_CONTAINER,
     SUMMARIES_CONTAINER,
     TRANSCRIPTS_CONTAINER,
     get_blob_client,
@@ -106,8 +107,9 @@ class EmbedWorker(BaseWorker[EmbedMessage]):
                 message.channel_name, message.youtube_video_id
             )
             segments_json = await self._fetch_content(
-                TRANSCRIPTS_CONTAINER,
+                LIBRARY_CONTAINER,
                 segments_blob_path,
+                fallback_container=TRANSCRIPTS_CONTAINER,
             )
 
             timestamped_segments = None
@@ -139,12 +141,14 @@ class EmbedWorker(BaseWorker[EmbedMessage]):
                 )
 
                 transcript = await self._fetch_content(
-                    TRANSCRIPTS_CONTAINER,
+                    LIBRARY_CONTAINER,
                     transcript_blob_path,
+                    fallback_container=TRANSCRIPTS_CONTAINER,
                 )
                 summary = await self._fetch_content(
-                    SUMMARIES_CONTAINER,
+                    LIBRARY_CONTAINER,
                     summary_blob_path,
+                    fallback_container=SUMMARIES_CONTAINER,
                 )
 
                 if not transcript and not summary:
@@ -203,10 +207,18 @@ class EmbedWorker(BaseWorker[EmbedMessage]):
             await mark_job_failed(message.job_id, str(e))
             return WorkerResult.failed(e)
 
-    async def _fetch_content(self, container: str, blob_name: str) -> str | None:
+    async def _fetch_content(
+        self,
+        container: str,
+        blob_name: str,
+        *,
+        fallback_container: str | None = None,
+    ) -> str | None:
         """Fetch content from blob storage."""
         try:
             blob_client = get_blob_client()
+            if not blob_client.blob_exists(container, blob_name) and fallback_container:
+                container = fallback_container
             content = blob_client.download_blob(container, blob_name)
             return content.decode("utf-8")
         except Exception as e:

--- a/services/workers/summarize/worker.py
+++ b/services/workers/summarize/worker.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from shared.blob.client import (
     LIBRARY_CONTAINER,
-    SUMMARIES_CONTAINER,
     TRANSCRIPTS_CONTAINER,
     compute_content_hash,
     get_blob_client,

--- a/services/workers/summarize/worker.py
+++ b/services/workers/summarize/worker.py
@@ -13,6 +13,7 @@ except ImportError:
     pass  # certifi not installed, use system defaults
 
 from shared.blob.client import (
+    LIBRARY_CONTAINER,
     SUMMARIES_CONTAINER,
     TRANSCRIPTS_CONTAINER,
     compute_content_hash,
@@ -20,6 +21,7 @@ from shared.blob.client import (
     get_summary_blob_path,
     get_transcript_blob_path,
 )
+from shared.blob.metadata import metadata_artifact_ref, write_video_metadata
 from shared.config import get_settings
 from shared.db.connection import get_db
 from shared.db.job_service import mark_job_completed, mark_job_failed, mark_job_running
@@ -189,6 +191,10 @@ class SummarizeWorker(BaseWorker[SummarizeMessage]):
                 blob_uri,
                 summary,
             )
+            await self._write_metadata(
+                message.video_id,
+                {"summary": metadata_artifact_ref(summary.encode("utf-8"), blob_uri)},
+            )
 
             # Generate segment labels (best-effort, does not fail the job)
             openai_client = await self._get_openai_client()
@@ -229,7 +235,10 @@ class SummarizeWorker(BaseWorker[SummarizeMessage]):
         try:
             blob_client = get_blob_client()
             blob_name = get_transcript_blob_path(channel_name, youtube_video_id)
-            content = blob_client.download_blob(TRANSCRIPTS_CONTAINER, blob_name)
+            container_name = LIBRARY_CONTAINER
+            if not blob_client.blob_exists(LIBRARY_CONTAINER, blob_name):
+                container_name = TRANSCRIPTS_CONTAINER
+            content = blob_client.download_blob(container_name, blob_name)
             return content.decode("utf-8")
         except Exception as e:
             logger.error(
@@ -422,10 +431,10 @@ This is a placeholder summary for testing purposes. Configure an OpenAI API key 
         blob_name = get_summary_blob_path(channel_name, youtube_video_id)
 
         uri = blob_client.upload_blob(
-            SUMMARIES_CONTAINER,
+            LIBRARY_CONTAINER,
             blob_name,
             summary.encode("utf-8"),
-            content_type="text/markdown",
+            content_type="text/markdown; charset=utf-8",
         )
 
         return uri
@@ -467,6 +476,16 @@ This is a placeholder summary for testing purposes. Configure an OpenAI API key 
                     content_hash=compute_content_hash(summary.encode("utf-8")),
                 )
                 session.add(artifact)
+
+    async def _write_metadata(
+        self,
+        video_id: str,
+        extra_artifacts: dict[str, dict[str, Any]],
+    ) -> None:
+        """Write metadata.json for the self-contained video folder."""
+        db = get_db()
+        async with db.session() as session:
+            await write_video_metadata(session, video_id, extra_artifacts=extra_artifacts)
 
     async def _queue_next_job(
         self,

--- a/services/workers/tests/test_library_layout_migration.py
+++ b/services/workers/tests/test_library_layout_migration.py
@@ -1,0 +1,117 @@
+"""Tests for the one-shot library blob layout migration."""
+
+from azure.core.exceptions import ResourceNotFoundError
+from shared.blob import LIBRARY_CONTAINER, TRANSCRIPTS_CONTAINER, compute_content_hash
+
+from backup.migrate_library_layout import LibraryLayoutMigrator, VideoMigrationResult
+
+
+class _MemoryBlobClient:
+    def __init__(self, blobs: dict[tuple[str, str], bytes] | None = None):
+        self.blobs = blobs or {}
+        self.deleted: list[tuple[str, str]] = []
+
+    def download_blob(self, container_name: str, blob_name: str) -> bytes:
+        key = (container_name, blob_name)
+        if key not in self.blobs:
+            raise ResourceNotFoundError("missing")
+        return self.blobs[key]
+
+    def upload_blob(
+        self,
+        container_name: str,
+        blob_name: str,
+        content: bytes,
+        content_type: str,
+        overwrite: bool = True,
+    ) -> str:
+        self.blobs[(container_name, blob_name)] = content
+        return self.get_blob_url(container_name, blob_name)
+
+    def get_blob_url(self, container_name: str, blob_name: str) -> str:
+        return f"https://storage.test/{container_name}/{blob_name}"
+
+    def delete_blob(self, container_name: str, blob_name: str) -> None:
+        self.deleted.append((container_name, blob_name))
+        self.blobs.pop((container_name, blob_name), None)
+
+
+def test_copy_and_verify_dry_run_does_not_write_destination():
+    blob_path = "mark-wildman/video/transcript.txt"
+    blob_client = _MemoryBlobClient({(TRANSCRIPTS_CONTAINER, blob_path): b"hello"})
+    migrator = LibraryLayoutMigrator(
+        dry_run=True,
+        delete_verified=False,
+        channels=[],
+        blob_client=blob_client,
+    )
+
+    result = migrator._copy_and_verify_artifact("transcript", TRANSCRIPTS_CONTAINER, blob_path)
+
+    assert result.status == "would_copy"
+    assert (LIBRARY_CONTAINER, blob_path) not in blob_client.blobs
+    assert result.source_hash == compute_content_hash(b"hello")
+
+
+def test_copy_and_verify_execute_writes_library_blob():
+    blob_path = "mark-wildman/video/transcript.txt"
+    blob_client = _MemoryBlobClient({(TRANSCRIPTS_CONTAINER, blob_path): b"hello"})
+    migrator = LibraryLayoutMigrator(
+        dry_run=False,
+        delete_verified=True,
+        channels=[],
+        blob_client=blob_client,
+    )
+
+    result = migrator._copy_and_verify_artifact("transcript", TRANSCRIPTS_CONTAINER, blob_path)
+
+    assert result.status == "copied"
+    assert blob_client.blobs[(LIBRARY_CONTAINER, blob_path)] == b"hello"
+    assert result.source_hash == result.destination_hash
+
+
+def test_copy_and_verify_missing_source_is_not_failure():
+    blob_client = _MemoryBlobClient()
+    migrator = LibraryLayoutMigrator(
+        dry_run=False,
+        delete_verified=True,
+        channels=[],
+        blob_client=blob_client,
+    )
+
+    result = migrator._copy_and_verify_artifact(
+        "transcript",
+        TRANSCRIPTS_CONTAINER,
+        "mark-wildman/video/transcript.txt",
+    )
+
+    assert result.status == "missing"
+
+
+def test_delete_verified_legacy_blobs_only_after_success():
+    blob_path = "mark-wildman/video/transcript.txt"
+    blob_client = _MemoryBlobClient({(TRANSCRIPTS_CONTAINER, blob_path): b"hello"})
+    migrator = LibraryLayoutMigrator(
+        dry_run=False,
+        delete_verified=True,
+        channels=[],
+        blob_client=blob_client,
+    )
+    result = VideoMigrationResult(
+        video_id="video-id",
+        youtube_video_id="youtube-id",
+        channel_slug="mark-wildman",
+        status="partial",
+        verified_legacy_blobs=[(TRANSCRIPTS_CONTAINER, blob_path)],
+    )
+
+    migrator._delete_verified_legacy_blobs(result)
+
+    assert blob_client.deleted == []
+    assert (TRANSCRIPTS_CONTAINER, blob_path) in blob_client.blobs
+
+    result.status = "succeeded"
+    migrator._delete_verified_legacy_blobs(result)
+
+    assert blob_client.deleted == [(TRANSCRIPTS_CONTAINER, blob_path)]
+    assert (TRANSCRIPTS_CONTAINER, blob_path) not in blob_client.blobs

--- a/services/workers/tests/test_workers.py
+++ b/services/workers/tests/test_workers.py
@@ -220,6 +220,7 @@ class TestTranscribeWorkerProcessing:
                 worker, "_store_timestamped_segments", new_callable=AsyncMock
             ) as mock_store_ts,
             patch.object(worker, "_create_artifact", new_callable=AsyncMock) as mock_artifact,
+            patch.object(worker, "_write_metadata", new_callable=AsyncMock) as mock_metadata,
             patch.object(worker, "_queue_next_job", new_callable=AsyncMock) as mock_queue,
             patch.object(worker, "_has_permanent_no_captions", return_value=False),
         ):
@@ -231,8 +232,11 @@ class TestTranscribeWorkerProcessing:
                     {"start": 5.0, "duration": 5.0, "text": "This is a test"},
                 ],
             )
-            mock_store.return_value = f"transcripts/{sample_video_id}.txt"
-            mock_store_ts.return_value = f"transcripts/{sample_video_id}_segments.json"
+            mock_store.return_value = f"library/test-channel/{sample_video_id}/transcript.txt"
+            mock_store_ts.return_value = (
+                f"library/test-channel/{sample_video_id}/segments.json",
+                b"[]",
+            )
 
             # Process the message
             result = await worker.process_message(message, sample_correlation_id)
@@ -250,6 +254,7 @@ class TestTranscribeWorkerProcessing:
 
             # Verify timestamped segments were stored
             mock_store_ts.assert_called_once()
+            mock_metadata.assert_called_once()
 
             # Verify next job was queued
             mock_queue.assert_called_once()
@@ -332,6 +337,7 @@ class TestSummarizeWorkerProcessing:
             patch.object(worker, "_generate_summary", new_callable=AsyncMock) as mock_gen,
             patch.object(worker, "_store_summary", new_callable=AsyncMock) as mock_store,
             patch.object(worker, "_create_artifact", new_callable=AsyncMock) as mock_artifact,
+            patch.object(worker, "_write_metadata", new_callable=AsyncMock) as mock_metadata,
             patch.object(worker, "_queue_next_job", new_callable=AsyncMock) as mock_queue,
         ):
             mock_fetch.return_value = sample_transcript
@@ -339,13 +345,14 @@ class TestSummarizeWorkerProcessing:
                 sample_summary,
                 sample_summary,
             )  # Returns tuple (summary, summary_text)
-            mock_store.return_value = f"summaries/{sample_video_id}.md"
+            mock_store.return_value = f"library/test-channel/{sample_video_id}/summary.md"
 
             result = await worker.process_message(message, sample_correlation_id)
 
             assert result.status == WorkerStatus.SUCCESS
             mock_running.assert_called_once_with(sample_job_id, "summarizing")
             mock_completed.assert_called_once_with(sample_job_id)
+            mock_metadata.assert_called_once()
             mock_queue.assert_called_once()
 
 

--- a/services/workers/transcribe/worker.py
+++ b/services/workers/transcribe/worker.py
@@ -7,12 +7,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from shared.blob.client import (
+    LIBRARY_CONTAINER,
     TRANSCRIPTS_CONTAINER,
     compute_content_hash,
     get_blob_client,
     get_segments_blob_path,
     get_transcript_blob_path,
 )
+from shared.blob.metadata import metadata_artifact_ref, write_video_metadata
 from shared.config import get_settings
 from shared.db.connection import get_db
 from shared.db.job_service import (
@@ -404,18 +406,25 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
 
         try:
             # Store transcript in blob storage (using channel-based path)
+            transcript_content = transcript.encode("utf-8")
             blob_uri = await self._store_transcript(
                 message.channel_name,
                 message.youtube_video_id,
                 transcript,
             )
+            extra_artifacts: dict[str, dict[str, Any]] = {
+                "transcript": metadata_artifact_ref(transcript_content, blob_uri)
+            }
 
             # Store timestamped segments (already fetched above, no extra API call)
             if timestamped_segments:
-                await self._store_timestamped_segments(
+                segments_uri, segments_content = await self._store_timestamped_segments(
                     message.channel_name,
                     message.youtube_video_id,
                     timestamped_segments,
+                )
+                extra_artifacts["segments"] = metadata_artifact_ref(
+                    segments_content, segments_uri
                 )
 
             # Create artifact record
@@ -424,6 +433,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                 blob_uri,
                 transcript,
             )
+            await self._write_metadata(message.video_id, extra_artifacts)
 
             # Mark job as completed
             await mark_job_completed(message.job_id)
@@ -544,22 +554,29 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
 
         blob_client = get_blob_client()
 
-        # Check for transcript using the YouTube video ID path
         transcript_path = get_transcript_blob_path(channel_name, youtube_video_id)
         segments_path = get_segments_blob_path(channel_name, youtube_video_id)
 
         try:
-            if not blob_client.blob_exists(TRANSCRIPTS_CONTAINER, transcript_path):
+            transcript_container = LIBRARY_CONTAINER
+            segments_container = LIBRARY_CONTAINER
+            if not blob_client.blob_exists(LIBRARY_CONTAINER, transcript_path):
+                if not blob_client.blob_exists(TRANSCRIPTS_CONTAINER, transcript_path):
+                    return None
+                transcript_container = TRANSCRIPTS_CONTAINER
+                segments_container = TRANSCRIPTS_CONTAINER
+
+            if not blob_client.blob_exists(transcript_container, transcript_path):
                 return None
 
             # Download existing transcript
-            transcript_bytes = blob_client.download_blob(TRANSCRIPTS_CONTAINER, transcript_path)
+            transcript_bytes = blob_client.download_blob(transcript_container, transcript_path)
             transcript = transcript_bytes.decode("utf-8")
 
             # Try to get segments too
             segments = []
-            if blob_client.blob_exists(TRANSCRIPTS_CONTAINER, segments_path):
-                segments_bytes = blob_client.download_blob(TRANSCRIPTS_CONTAINER, segments_path)
+            if blob_client.blob_exists(segments_container, segments_path):
+                segments_bytes = blob_client.download_blob(segments_container, segments_path)
                 segments = json.loads(segments_bytes.decode("utf-8"))
 
             logger.info(
@@ -923,10 +940,10 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
         blob_name = get_transcript_blob_path(channel_name, youtube_video_id)
 
         uri = blob_client.upload_blob(
-            TRANSCRIPTS_CONTAINER,
+            LIBRARY_CONTAINER,
             blob_name,
             transcript.encode("utf-8"),
-            content_type="text/plain",
+            content_type="text/plain; charset=utf-8",
         )
 
         logger.info(
@@ -943,7 +960,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
         channel_name: str,
         youtube_video_id: str,
         segments: list[dict],
-    ) -> str:
+    ) -> tuple[str, bytes]:
         """Store timestamped transcript segments as JSON for semantic search.
 
         Groups small segments into ~30 second chunks for better semantic coherence
@@ -1002,11 +1019,12 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
         blob_client = get_blob_client()
         blob_name = get_segments_blob_path(channel_name, youtube_video_id)
 
+        content = json.dumps(chunked_segments).encode("utf-8")
         uri = blob_client.upload_blob(
-            TRANSCRIPTS_CONTAINER,
+            LIBRARY_CONTAINER,
             blob_name,
-            json.dumps(chunked_segments).encode("utf-8"),
-            content_type="application/json",
+            content,
+            content_type="application/json; charset=utf-8",
         )
 
         logger.info(
@@ -1017,7 +1035,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
             segment_count=len(chunked_segments),
         )
 
-        return uri
+        return uri, content
 
     async def _create_artifact(
         self,
@@ -1056,6 +1074,16 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                     content_hash=compute_content_hash(transcript.encode("utf-8")),
                 )
                 session.add(artifact)
+
+    async def _write_metadata(
+        self,
+        video_id: str,
+        extra_artifacts: dict[str, dict[str, Any]],
+    ) -> None:
+        """Write metadata.json for the self-contained video folder."""
+        db = get_db()
+        async with db.session() as session:
+            await write_video_metadata(session, video_id, extra_artifacts=extra_artifacts)
 
     async def _queue_next_job(
         self,

--- a/services/workers/transcribe/worker.py
+++ b/services/workers/transcribe/worker.py
@@ -423,9 +423,7 @@ class TranscribeWorker(BaseWorker[TranscribeMessage]):
                     message.youtube_video_id,
                     timestamped_segments,
                 )
-                extra_artifacts["segments"] = metadata_artifact_ref(
-                    segments_content, segments_uri
-                )
+                extra_artifacts["segments"] = metadata_artifact_ref(segments_content, segments_uri)
 
             # Create artifact record
             await self._create_artifact(


### PR DESCRIPTION
## Summary
- Move live video blob artifacts to the canonical `library/<channel>/<youtube_video_id>/` layout.
- Add `metadata.json` generation/refresh for self-contained video folders.
- Keep rollout-safe legacy read fallback for `transcripts` and `summaries`.
- Add a one-shot migration command that copies, verifies hashes, updates artifact URIs, writes metadata, and deletes verified legacy blobs only after the per-video SQL transaction commits.
- Update nightly backups to read the new `library` layout first with legacy fallback.
- Add Terraform-managed `library` blob container in PROD.

## Migration Runbook
Dry run a channel:

```powershell
cd services/workers
uv run python -m backup.migrate_library_layout --dry-run --channel mark-wildman
```

Execute and delete only per-video verified legacy blobs:

```powershell
cd services/workers
uv run python -m backup.migrate_library_layout --execute --delete-verified --channel mark-wildman
```

The migration reports per-video artifact status and only deletes legacy blobs after the copied destination hashes verify and SQL has committed.

## Validation
- `./scripts/run-tests.ps1` -> 807 passed, 0 failed
- `python -m pre_commit run --all-files --verbose` -> passed