### PR TITLE
Fix library migration dry-run session handling

### DIFF
--- a/services/workers/backup/migrate_library_layout.py
+++ b/services/workers/backup/migrate_library_layout.py
@@ -123,9 +123,7 @@ class LibraryLayoutMigrator:
                 for video in videos:
                     try:
                         result = await self._migrate_video(session, video)
-                        if self.dry_run:
-                            await session.rollback()
-                        else:
+                        if not self.dry_run:
                             await session.commit()
                     except Exception:
                         await session.rollback()


### PR DESCRIPTION
## Summary
- avoid rolling back after each dry-run video so selected ORM rows are not expired mid-run
- preserve per-video commit/rollback behavior for execute mode

## Validation
- services/workers: pytest tests/test_library_layout_migration.py -q
- services/workers: ruff format/check on migrate_library_layout.py
- ./scripts/run-tests.ps1 -Component workers
- python -m pre_commit run --all-files --verbose

## Operational note
The PROD built-in dry-run canary on sha-bd01c9e failed with MissingGreenlet after per-video dry-run rollback expired the loaded video objects. No migration writes/deletes occurred.