### PR TITLE
fix(agent): use Azure client for chat completions

### DIFF
--- a/services/api/src/api/agents/yt_summarizer_agent.py
+++ b/services/api/src/api/agents/yt_summarizer_agent.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
 import httpx
+from openai import AsyncAzureOpenAI
 
 # Import Agent Framework components
 try:
@@ -488,10 +489,25 @@ def create_openai_chat_client() -> BaseChatClient | None:
     azure_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
 
     if azure_endpoint and azure_api_key:
-        # Detect endpoint type and construct appropriate base_url
+        # Azure AI Foundry exposes an OpenAI-compatible /models endpoint.
         base_url = _build_azure_openai_base_url(azure_endpoint, azure_deployment)
 
         logger.info(f"Using Azure OpenAI - deployment: {azure_deployment}, base_url: {base_url}")
+
+        if "services.ai.azure.com" not in azure_endpoint:
+            # Standard Azure OpenAI requires api-version as a query parameter.  Passing it
+            # through default_headers produces a valid-looking request that Azure answers
+            # with 404 Resource not found.  AsyncAzureOpenAI owns the Azure URL and query
+            # construction, while Agent Framework continues to provide the chat abstraction.
+            azure_client = AsyncAzureOpenAI(
+                api_key=azure_api_key,
+                azure_endpoint=azure_endpoint.rstrip("/"),
+                api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview"),
+            )
+            return OpenAIChatClient(
+                model_id=azure_deployment,
+                async_client=azure_client,
+            )
 
         return OpenAIChatClient(
             model_id=azure_deployment,

--- a/services/api/tests/test_agents.py
+++ b/services/api/tests/test_agents.py
@@ -330,6 +330,43 @@ class TestAzureEndpointURLBuilding:
         )
 
     @requires_agent_framework
+    def test_standard_azure_openai_uses_azure_client(self, monkeypatch):
+        """Verify standard Azure endpoints use SDK-managed api-version query parameters."""
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test.openai.azure.com/")
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-5-mini")
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+
+        from src.api.agents import yt_summarizer_agent as agent_module
+
+        captured: dict[str, object] = {}
+        azure_client = object()
+
+        def fake_azure_client(**kwargs):
+            captured["azure_kwargs"] = kwargs
+            return azure_client
+
+        def fake_chat_client(**kwargs):
+            captured["chat_kwargs"] = kwargs
+            return kwargs
+
+        monkeypatch.setattr(agent_module, "AsyncAzureOpenAI", fake_azure_client)
+        monkeypatch.setattr(agent_module, "OpenAIChatClient", fake_chat_client)
+
+        client = agent_module.create_openai_chat_client()
+
+        assert captured["azure_kwargs"] == {
+            "api_key": "test-api-key",
+            "azure_endpoint": "https://test.openai.azure.com",
+            "api_version": "2024-10-21",
+        }
+        assert captured["chat_kwargs"] == {
+            "model_id": "gpt-5-mini",
+            "async_client": azure_client,
+        }
+        assert client == captured["chat_kwargs"]
+
+    @requires_agent_framework
     def test_agent_does_not_set_max_tokens(self, monkeypatch):
         """Verify agent doesn't set max_tokens (causes errors with newer models).
 


### PR DESCRIPTION
## Summary

- use `AsyncAzureOpenAI` for standard Azure OpenAI agent chat requests
- let the Azure SDK supply `api-version` as a query parameter instead of an invalid header
- retain the existing Azure AI Foundry OpenAI-compatible client path
- add focused regression coverage for endpoint, deployment, and API-version wiring

## Production evidence

- canonical OpenClaw health endpoints return 200
- direct Azure chat and 1,536-dimension embedding requests return 200
- current production Copilot request reproduces `404 Resource not found`
- patched client completes a real request against the configured Azure chat deployment

## Verification

- 494 API tests passed (`not integration and not live`)
- Ruff check and format check passed
- pre-commit passed on all files
- unified PowerShell runner was attempted but `pwsh` is unavailable on the Linux host; PR CI and preview E2E remain required
